### PR TITLE
Slow synchronization - BR and save unit optimization

### DIFF
--- a/Blizzard.eai
+++ b/Blizzard.eai
@@ -588,25 +588,34 @@ endfunction
 
 function InitZoom takes nothing returns nothing
   local integer i = 0
+  local player p = null
   if ZoomSetx == null then
+    loop
+      exitwhen i >= GetBJMaxPlayers()
+      set p = Player(i)
+      if IsPlayerObserver(p) then
+        call SetCameraFieldForPlayer( p, CAMERA_FIELD_TARGET_DISTANCE, 2500, 0 )
+      endif
+      set i = i + 1
+    endloop
     set ZoomSetx = CreateTrigger()
     set AdjustZoomUp = CreateTrigger()
     set AdjustZoomDown = CreateTrigger()
-    //loop
-    //  exitwhen i >= GetBJMaxPlayers()
-      //call SetCameraFieldForPlayer( Player(i), CAMERA_FIELD_TARGET_DISTANCE, 2500, 0 ) // not required in latest war3
-      if (GetPlayerController(GetLocalPlayer()) != MAP_CONTROL_COMPUTER) or IsPlayerObserver(GetLocalPlayer()) then
-        call TriggerRegisterPlayerChatEvent( ZoomSetx, GetLocalPlayer(), "-zoom", false )
-        //call TriggerRegisterPlayerKeyEventBJ( AdjustZoomUp, Player(i), bj_KEYEVENTTYPE_DEPRESS, bj_KEYEVENTKEY_UP ) // not required in latest war3
-        //call TriggerRegisterPlayerKeyEventBJ( AdjustZoomDown, Player(i), bj_KEYEVENTTYPE_DEPRESS, bj_KEYEVENTKEY_DOWN )
-        call TriggerAddAction(ZoomSetx, function ZoomSet)
-        call TriggerAddAction(AdjustZoomUp , function ZoomUp)
-        call TriggerAddAction(AdjustZoomDown , function ZoomDown)
-      endif
-    //  set i = i + 1
-    //endloop
+    call DisplayToAll("Zoom is set to: |c00d5f038-zoom1750|r")
+    call TriggerAddAction(ZoomSetx, function ZoomSet)
+    call TriggerAddAction(AdjustZoomUp , function ZoomUp)
+    call TriggerAddAction(AdjustZoomDown , function ZoomDown)
+    set i = 0
   endif
-
+  loop
+    exitwhen i >= GetBJMaxPlayers()
+    set p = Player(i)
+    call TriggerRegisterPlayerKeyEventBJ( AdjustZoomUp, p, bj_KEYEVENTTYPE_DEPRESS, bj_KEYEVENTKEY_UP )
+    call TriggerRegisterPlayerKeyEventBJ( AdjustZoomDown, p, bj_KEYEVENTTYPE_DEPRESS, bj_KEYEVENTKEY_DOWN )
+    call TriggerRegisterPlayerChatEvent( ZoomSetx, p, "-zoom", false )
+    set i = i + 1
+  endloop
+  set p = null
 endfunction
 
 

--- a/Jobs/ANCIENT_EXPANSION.eai
+++ b/Jobs/ANCIENT_EXPANSION.eai
@@ -91,7 +91,7 @@ if GetGold() < GetUnitGoldCost2(racial_expansion) or GetWood() < GetUnitWoodCost
 			//set exp_loc = GetUnitLoc(current_expansion)
 			if ancient_exp_loc == null then
 				set temp = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), old_id[racial_expansion], GetUnitX(current_expansion), GetUnitY(current_expansion), 270.0)
-				set exp_loc = Location(GetUnitX(temp),GetUnitY(temp))
+				set exp_loc = GetUnitLoc(temp)
 				call RemoveUnit(temp)
 				call IssuePointOrderByIdLoc(ancient_exp_wisp,old_id[racial_expansion], exp_loc)
 				call RemoveLocation(exp_loc)

--- a/Jobs/DETECT_DEFEAT.eai
+++ b/Jobs/DETECT_DEFEAT.eai
@@ -19,6 +19,7 @@ function SaveYourself takes nothing returns boolean
     endif
     if race_ancient_expansion_available == true and TownCountDone(racial_expansion) > 0 then
       call TQAddJob(2, ANCIENT_EXPANSION, 0)
+      set ancient_exp_nobuild = true
       set SaveYourselfMode = 1
       set b = true
     elseif race_militia_available == true then
@@ -40,9 +41,6 @@ function SaveYourself takes nothing returns boolean
         set b = true
       endif
     endif
-  endif
-  if b == true then  // b is false then Self rescue failure
-    call TQAddJob(13 * sleep_multiplier, DETECT_DEFEAT, 0)
   endif
   return b
 endfunction

--- a/Jobs/HARASS.eai
+++ b/Jobs/HARASS.eai
@@ -3,85 +3,78 @@
     constant integer HARASS_TARGET_EXPANSION = 1
     constant integer HARASS_TARGET_LOCATION = 2
     constant integer HARASS_TARGET_MAIN_HALL = 3
-    
-
     integer array harass_time
     integer array harass_size
     integer distraction_group = 0
 #ELSE
-function GetHarassPeonTarget takes unit u returns unit
+function GetHarassPeonTarget takes unit ru, unit u returns unit
   local group g = CreateGroup()
   local location unitloc = GetUnitLoc(u)
   local player p = GetNearestEnemyToLoc_k(unitloc)
-  local unit tempu = null
-  
+
   call GroupEnumUnitsOfPlayer(g, p, null)
   set g = SelectUnittype(g, UNIT_TYPE_PEON, true)
   set g = SelectByAlive(g, true)
   set g = SelectByLoaded(g, false)
   set g = SelectByHidden(g, false) // Hopefully to get peons not currently building
-  set tempu = GetNearestOfGroup(g, unitloc)
+  set ru = GetNearestOfGroup(g, unitloc)
   call RemoveLocation(unitloc)
   call DestroyGroup(g)
   set unitloc = null
   set g = null
   set p = null
-  return tempu 
+  return ru
 endfunction
 
-function GetHarassExpansionTarget takes unit u returns unit
+function GetHarassExpansionTarget takes unit ru, unit u returns unit
   local group g = CreateGroup()
   local location unitloc = GetUnitLoc(u)
   local player p = GetNearestEnemyToLoc_k(unitloc)  
   local location baseloc = GetPlayerStartLocationLoc(p)
-  local unit tempu = null
-  
   call GroupEnumUnitsOfPlayer(g, p, null)
   set g = SelectUnittype(g, UNIT_TYPE_TOWNHALL, true)
   set g = SelectByLocation(g, baseloc, 1000, false)
   set g = SelectByAlive(g, true)
-  set tempu = GetNearestOfGroup(g, unitloc)
+  set ru = GetNearestOfGroup(g, unitloc)
   call RemoveLocation(unitloc)
   call RemoveLocation(baseloc)
   call DestroyGroup(g)
   set unitloc = null
+  set baseloc = null
   set g = null
   set p = null
-  set baseloc = null
-  return tempu 
+  return ru
 endfunction
 
-function GetHarassLocationTarget takes real x, real y returns unit
+function GetHarassLocationTarget takes unit ru, real x, real y returns unit
   local group g = CreateGroup()
-  local unit u = null
   call GroupEnumUnitsInRange(g, x, y, 1000, null)
   set g = SelectByEnemy(g, ai_player, true)
   set g = SelectByAlive(g, true)
-  set u = GetLeastHPUnitOfGroup(g)
+  set ru = GetLeastHPUnitOfGroup(g)
   set g = null
-  return u
+  return ru
 endfunction
 
-function GetHarassMainHallTarget takes unit u returns unit
+function GetHarassMainHallTarget takes unit ru, unit u returns unit
   local group g = CreateGroup()
   local location unitloc = GetUnitLoc(u)
   local player p = GetNearestEnemyToLoc_k(unitloc)  
   local location baseloc = GetPlayerStartLocationLoc(p)
-  local unit tempu = null
-  
+
   call GroupEnumUnitsOfPlayer(g, p, null)
   set g = SelectUnittype(g, UNIT_TYPE_TOWNHALL, true)
-  set g = SelectByLocation(g, baseloc, 1000, true)
   set g = SelectByAlive(g, true)
-  set tempu = GetNearestOfGroup(g, unitloc)
+  set g = SelectByLocation(g, baseloc, 1000, true)
+  set ru = GetNearestOfGroup(g, unitloc)
   call RemoveLocation(unitloc)
   call RemoveLocation(baseloc)
   call DestroyGroup(g)
   set unitloc = null
-  set g = null  
-  set p = null
   set baseloc = null
-  return tempu
+  set g = null
+  set p = null
+  return ru
 endfunction
 
 function GroupOrderWindWalkInstant_d takes group g returns nothing
@@ -89,9 +82,11 @@ function GroupOrderWindWalkInstant_d takes group g returns nothing
 	loop
 		set u = FirstOfGroup(g)
 		exitwhen u == null
-		if not IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
-			//call CreateDebugTag("HARASS: WINDWALK COMMANDED", 10, u, 3.00, 1.50)
-			call IssueImmediateOrder(u, "windwalk")
+		if GetUnitAbilityLevel(u, 'AOwk') > 0 or GetUnitAbilityLevel(u, 'ANwk') > 0 then
+			if not IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
+				//call CreateDebugTag("HARASS: WINDWALK COMMANDED", 10, u, 3.00, 1.50)
+				call IssueImmediateOrder(u, "windwalk")
+			endif
 		endif
 		call GroupRemoveUnit(g, u)
 	endloop
@@ -107,201 +102,205 @@ function HarassJob takes integer ht, unit targ, group harasser returns nothing
   local boolean avoiding_towers = LoadBoolean(additional_info, key, AVOID_TOWERS)
   local boolean state_retreat = LoadBoolean(additional_info, key, STATE_RETREAT)
   local real start_strength = LoadReal(additional_info, key, START_STRENGTH)
-  local group g = null
   local unit u = null
+  local unit hu = null
+  local player p = null
   local real strength_sum = 0
   local real player_sum = 0
   local integer harass_num = 0
   local boolean towersdetected = false
-  local location l = null
   local boolean hero_harass = false
   local integer hiddencount = LoadInteger(additional_info, key, INVISIBLE_COUNT)
   local integer timedelay = LoadInteger(additional_info, key, WINDWALK_COUNT) // Delay count so windwalkers show themselves after a period of waiting
 
   call DisplayToAllJobDebug("HARASS JOB START")
   if not UnitAliveInGroup(harasser) then
+    set target = null
     return
   endif
+  set hu = FirstOfGroup(harasser)
+  if hu == hero_unit[1] or hu == hero_unit[2] or hu == hero_unit[3] then
+    //call Trace("HARASS WITH HERO RAN")
+    set hero_harass = true
+  endif
 
-  if FirstOfGroup(harasser) == hero_unit[1] or FirstOfGroup(harasser) == hero_unit[2] then
-//	call Trace("HARASS WITH BLADEMASTER RAN")
-	set hero_harass = true
-  endif
-  
-  if (town_threatened and not state_attacking) or (town_threatened and hero_harass) then
+  if town_threatened and (not state_attacking or hero_harass) then
     call TQAddGroupJob(5 * sleep_multiplier, HARASS, ht, target, harasser)
-	return
+    set target = null
+    set hu = null
+    return
   endif
-  
-  set l = GetUnitLoc(FirstOfGroup(harasser))
-  if state_retreat and DistanceBetweenPoints(l, home_location) > 1000 then
-	call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
-	call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
-	call TQAddGroupJob(3 * sleep_multiplier, HARASS, ht, target, harasser)
-	//call GroupRemoveUnit(unit_harassing, FirstOfGroup(harasser))
-	call RemoveLocation(l)
-	set l = null
-	return
-  elseif state_retreat then
-    call SaveBoolean(additional_info, key, STATE_RETREAT , false)
-	//call GroupRecycleGuardPositionInstant(harasser)
-	call GroupRecycleHarrassPositionInstant(harasser)
-	call RemoveLocation(l)
-	set l = null
-	return
-  endif
-  	call RemoveLocation(l)
-	set l = null
-  
-  if target != null and (IsUnitHidden(target) or IsUnitLoaded(target) or IsUnitInvisible(target, ai_player)) then	// Checks to see if unit is not targetable and after small period will change to target it can hit
-	set hiddencount = hiddencount + 1
-	call SaveInteger(additional_info, key, INVISIBLE_COUNT , hiddencount)
-  else
-	set hiddencount = 0
-	call SaveInteger(additional_info, key, INVISIBLE_COUNT , hiddencount)
-  endif
-  
-  if target == null or not UnitAlive(target) or hiddencount > 2 then
-  	if target != null then
-		call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
-	endif
-    if ht == HARASS_TARGET_PEONS then
-      set target = GetHarassPeonTarget(FirstOfGroup(harasser))
-    elseif ht == HARASS_TARGET_EXPANSION then
-      set target = GetHarassExpansionTarget(FirstOfGroup(harasser))
-    elseif ht == HARASS_TARGET_LOCATION then
-      set target = GetHarassLocationTarget(LoadReal(additional_info, key, LOCX), LoadReal(additional_info, key, LOCY))
+  if state_retreat then
+    if DistanceBetweenPoints_dk(GetUnitLoc(hu), home_location) > 1000 then
+      call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
+      call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
+      call TQAddGroupJob(3 * sleep_multiplier, HARASS, ht, target, harasser)
+      //call GroupRemoveUnit(unit_harassing, hu)
+      set target = null
+      set hu = null
+      return
     else
-      set target = GetHarassMainHallTarget(FirstOfGroup(harasser))
+      call SaveBoolean(additional_info, key, STATE_RETREAT , false)
+      //call GroupRecycleGuardPositionInstant(harasser)
+      call GroupRecycleHarrassPositionInstant(harasser)
+      set target = null
+      set hu = null
+      return
     endif
   endif
-  
-  
-	//if not state_attacking then	// first run
-	    if avoiding_towers and GetLocationTowerStrength(GetUnitX(target), GetUnitY(target), ver_harass_tower_check_radius) > 0 then
-			set target = null
-	    else
-			//call GroupRemoveGuardPositionInstant(harasser)
-			
-		endif
-	//endif
-  
+
+  if target != null and (IsUnitHidden(target) or IsUnitLoaded(target) or IsUnitInvisible(target, ai_player)) then	// Checks to see if unit is not targetable and after small period will change to target it can hit
+    set hiddencount = hiddencount + 1
+    call SaveInteger(additional_info, key, INVISIBLE_COUNT , hiddencount)
+  else
+    set hiddencount = 0
+    call SaveInteger(additional_info, key, INVISIBLE_COUNT , hiddencount)
+  endif
+
+  if target == null or not UnitAlive(target) or hiddencount > 2 then
+    if target != null then
+      call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
+    endif
+    if ht == HARASS_TARGET_PEONS then
+      set target = GetHarassPeonTarget(target, hu)
+    elseif ht == HARASS_TARGET_EXPANSION then
+      set target = GetHarassExpansionTarget(target, hu)
+    elseif ht == HARASS_TARGET_LOCATION then
+      set target = GetHarassLocationTarget(target, LoadReal(additional_info, key, LOCX), LoadReal(additional_info, key, LOCY))
+    else
+      set target = GetHarassMainHallTarget(target, hu)
+    endif
+  endif
+
+  //if not state_attacking then	// first run
+  if target != null and avoiding_towers and GetLocationTowerStrength(GetUnitX(target), GetUnitY(target), ver_harass_tower_check_radius) > 0 then
+    set target = null
+  //else
+    //call GroupRemoveGuardPositionInstant(harasser)
+  endif
+  //endif
+
   if target != null and UnitAlive(target) then
-  
     set g = CreateGroup()
     //if state_attacking then
-    //  call GroupEnumUnitsInRange(g,GetUnitX(FirstOfGroup(harasser)),GetUnitY(FirstOfGroup(harasser)),harass_radius_attack_melee,null)
+    //  call GroupEnumUnitsInRange(g,GetUnitX(hu),GetUnitY(hu),harass_radius_attack_melee,null)
     //else
-    //  call GroupEnumUnitsInRange(g,GetUnitX(FirstOfGroup(harasser)),GetUnitY(FirstOfGroup(harasser)),harass_radius_flee_melee,null)
+    //  call GroupEnumUnitsInRange(g,GetUnitX(hu),GetUnitY(hu),harass_radius_flee_melee,null)
     //endif
-	//set g = SelectByAlive(g, true)
+    //set g = SelectByAlive(g, true)
     //loop
     //  set u = FirstOfGroup(g)
     //  exitwhen u == null
-    //  if IsPlayerEnemy(ai_player, GetOwningPlayer(u)) and IsUnitType(u, UNIT_TYPE_MELEE_ATTACKER) and GetOwningPlayer(u) != Player(PLAYER_NEUTRAL_AGGRESSIVE) and IsUnitType(u, UNIT_TYPE_PEON) == false then
+    //  set p = GetOwningPlayer(u)
+    //  if IsPlayerEnemy(ai_player, p) and IsUnitType(u, UNIT_TYPE_MELEE_ATTACKER) and p != Player(PLAYER_NEUTRAL_AGGRESSIVE) and IsUnitType(u, UNIT_TYPE_PEON) == false then
     //    set strength_sum = strength_sum + GetUnitStrength(u)
     //  endif
     //  call GroupRemoveUnit(g, u)
     //endloop
-    
+
     //call GroupClear(g)
     if state_attacking then
-      call GroupEnumUnitsInRange(g,GetUnitX(FirstOfGroup(harasser)),GetUnitY(FirstOfGroup(harasser)),harass_radius_attack_ranged,null)
+      call GroupEnumUnitsInRange(g,GetUnitX(hu),GetUnitY(hu),harass_radius_attack_ranged,null)
     else
-      call GroupEnumUnitsInRange(g,GetUnitX(FirstOfGroup(harasser)),GetUnitY(FirstOfGroup(harasser)),harass_radius_flee_ranged,null)
+      call GroupEnumUnitsInRange(g,GetUnitX(hu),GetUnitY(hu),harass_radius_flee_ranged,null)
     endif
-	set g = SelectByAlive(g, true)
+    set g = SelectByAlive(g, true)
     loop
       set u = FirstOfGroup(g)
       exitwhen u == null
-	  if IsPlayerEnemy(ai_player, GetOwningPlayer(u)) and IsUnitTower(u) and avoiding_towers then
-		set towersdetected = true
-	  endif	  
-      if IsPlayerEnemy(ai_player, GetOwningPlayer(u)) and IsUnitType(u, UNIT_TYPE_RANGED_ATTACKER) and GetOwningPlayer(u) != Player(PLAYER_NEUTRAL_AGGRESSIVE) and IsUnitType(u, UNIT_TYPE_PEON) == false then
-        set strength_sum = strength_sum + GetUnitStrength(u)
-      elseif IsUnitInGroup(u, harasser) then
-	     if ht == HARASS_TARGET_LOCATION then
-		 	call CreateDebugTag("Distraction: Harrasing Opponent Location", 10, u, 3.00, 1.50)
-		 else
-			call CreateDebugTag("Harassing Opponent", 10, u, 3.00, 1.50)
-		 endif
-		//if GetUnitState(u, UNIT_STATE_LIFE) <= GetUnitState(u, UNIT_STATE_MAX_LIFE) * flee_percent then
-		  
-		  if GetUnitState(u, UNIT_STATE_LIFE) <= RMax(flee_health_percentage * GetUnitState(u, UNIT_STATE_MAX_LIFE), flee_minimum_health) and not IsUnitInGroup(u, unit_healing) and IsUnitType(u, UNIT_TYPE_HERO) == false then // Not used on heroes as micro hero is in control of that
-		    call GroupAddUnit(unit_healing, u)
-			call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
-			call TQAddUnitJob(0.5, SEND_HOME, 50, u)
-			call GroupRemoveUnit(harasser, u)
-			call GroupRemoveUnit(unit_harassing, u)
-		  elseif IsUnitInGroup(u, unit_healing) then // Another system moved unit to healing
-			call GroupRemoveUnit(harasser, u)
-			call GroupRemoveUnit(unit_harassing, u)
-		  else
-		  	//call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
-			//call TQAddUnitJob(0.5, SEND_HOME, R2I(flee_percent * GetUnitState(u, UNIT_STATE_MAX_LIFE)), u)
-			set harass_num = harass_num + 1
-			set player_sum = player_sum + GetUnitStrength(u)
-		  endif
-        //else
+      if not IsUnitHidden(u) then
+        set p = GetOwningPlayer(u)
+        if IsPlayerEnemy(ai_player, p) and IsUnitTower(u) and avoiding_towers then
+          set towersdetected = true
+        endif
+        if IsPlayerEnemy(ai_player, p) and IsUnitType(u, UNIT_TYPE_RANGED_ATTACKER) and p != Player(PLAYER_NEUTRAL_AGGRESSIVE) and IsUnitType(u, UNIT_TYPE_PEON) == false then
+          set strength_sum = strength_sum + GetUnitStrength(u)
+        elseif IsUnitInGroup(u, harasser) then
+          if ht == HARASS_TARGET_LOCATION then
+            call CreateDebugTag("Distraction: Harrasing Opponent Location", 10, u, 3.00, 1.50)
+          else
+            call CreateDebugTag("Harassing Opponent", 10, u, 3.00, 1.50)
+          endif
+          //if GetUnitState(u, UNIT_STATE_LIFE) <= GetUnitState(u, UNIT_STATE_MAX_LIFE) * flee_percent then
 
-        //endif
+          if GetUnitState(u, UNIT_STATE_LIFE) <= RMax(flee_health_percentage * GetUnitState(u, UNIT_STATE_MAX_LIFE), flee_minimum_health) and not IsUnitInGroup(u, unit_healing) and IsUnitType(u, UNIT_TYPE_HERO) == false then // Not used on heroes as micro hero is in control of that
+            call GroupAddUnit(unit_healing, u)
+            call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
+            call TQAddUnitJob(0.5, SEND_HOME, 0, u)  // 0 is home_location
+            call GroupRemoveUnit(harasser, u)
+            call GroupRemoveUnit(unit_harassing, u)
+          elseif IsUnitInGroup(u, unit_healing) then // Another system moved unit to healing
+            call GroupRemoveUnit(harasser, u)
+            call GroupRemoveUnit(unit_harassing, u)
+          else
+            //call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
+            //call TQAddUnitJob(0.5, SEND_HOME, 0, u)  // 0 is home_location
+            set harass_num = harass_num + 1
+            set player_sum = player_sum + GetUnitStrength(u)
+          endif
+          //else
+
+          //endif
+        endif
       endif
       call GroupRemoveUnit(g, u)
     endloop
-
     call DestroyGroup(g)
     set g = null
-    set u = null
+    set p = null
+    set hu = FirstOfGroup(harasser)
     if harass_num <= LoadInteger(additional_info, key, FLEE_NUMBER) or towersdetected or (player_sum <= start_strength * flee_percent and not hero_harass) then
-	  call SaveBoolean(additional_info, key, STATE_RETREAT, true)
+      call SaveBoolean(additional_info, key, STATE_RETREAT, true)
       call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
       //call GroupRecycleGuardPosition(harasser)
       //return
     elseif strength_sum < strength_limit then
       call SaveBoolean(additional_info, key, STATE_ATTACKING, true)
-	  if IsUnitInvisible(FirstOfGroup(harasser), Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
-		set timedelay = timedelay + 1
-		call SaveInteger(additional_info, key, WINDWALK_COUNT, timedelay)
-	  else
-		set timedelay = -1	// Not a windwalker harassing so attack immediatly
-		call SaveInteger(additional_info, key, WINDWALK_COUNT, 0)		
-	  endif
-      if DistanceBetweenUnits(FirstOfGroup(harasser), target) > 650 then
-	  	  	if DistanceBetweenUnits(FirstOfGroup(harasser), target) <= 5000 then
-				call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
-			endif
-	    call CreateDebugTag("HARASS: Move to Target unit", 10, target, 3.00, 1.50)
+      if hu != null and IsUnitInvisible(hu, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
+        set timedelay = timedelay + 1
+        call SaveInteger(additional_info, key, WINDWALK_COUNT, timedelay)
+      else
+        set timedelay = -1	// Not a windwalker harassing so attack immediatly
+        call SaveInteger(additional_info, key, WINDWALK_COUNT, 0)
+      endif
+      if hu != null and DistanceBetweenUnits(hu, target) > 650 then
+        if DistanceBetweenUnits(hu, target) <= 5000 then
+          call GroupOrderWindWalkInstant_d(CopyGroup(harasser))
+        endif
+        call CreateDebugTag("HARASS: Move to Target unit", 10, target, 3.00, 1.50)
         call GroupPointOrder(harasser, "move", GetUnitX(target), GetUnitY(target))
       else
-	  	if timedelay >= 5 or timedelay == -1 or IsUnitDetected(FirstOfGroup(harasser), GetOwningPlayer(target)) then
-			call GroupTargetOrder(harasser, "attack", target)
-			call IssueTargetOrder(FirstOfGroup(harasser), "attack", target)
-		endif
-		call CreateDebugTag("HARASS: Attack Target", 10, target, 3.00, 1.50)
-	    //call CreateDebugTag("HARASS: Changing Target", 10, FirstOfGroup(harasser), 3.00, 1.50)
+        if timedelay >= 5 or timedelay == -1 or (hu != null and IsUnitDetected(hu, GetOwningPlayer(target))) then
+          call GroupTargetOrder(harasser, "attack", target)
+          call IssueTargetOrder(hu, "attack", target)
+        endif
+        call CreateDebugTag("HARASS: Attack Target", 10, target, 3.00, 1.50)
+        //call CreateDebugTag("HARASS: Changing Target", 10, hu, 3.00, 1.50)
         //call HarassJob(ht, null, harasser)
         //return
       endif
     elseif strength_sum >= strength_limit*2 then
-	  call SaveBoolean(additional_info, key, STATE_RETREAT, true)
+      call SaveBoolean(additional_info, key, STATE_RETREAT, true)
       call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
       call SaveBoolean(additional_info, key, STATE_ATTACKING, false)	
-      //call GroupRecycleGuardPosition(harasser)	  
-	else
-	  call SaveBoolean(additional_info, key, STATE_RETREAT, true)
+      //call GroupRecycleGuardPosition(harasser)
+    else
+      call SaveBoolean(additional_info, key, STATE_RETREAT, true)
       call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
       call SaveBoolean(additional_info, key, STATE_ATTACKING, false)
-	  //call TQAddGroupJob(30, HARASS, ht, target, harasser)
+      //call TQAddGroupJob(30, HARASS, ht, target, harasser)
     endif
   else
-//    call DisplayToAll("Target dead")
+    //call DisplayToAll("Target dead")
     call CreateDebugTag("HARASS: Target Dead", 10, target, 3.00, 1.50)
     call GroupPointOrder(harasser, "move", GetLocationX(home_location), GetLocationY(home_location))
-	call SaveBoolean(additional_info, key, STATE_RETREAT, true)
-	call SaveBoolean(additional_info, key, STATE_ATTACKING, false)
+    call SaveBoolean(additional_info, key, STATE_RETREAT, true)
+    call SaveBoolean(additional_info, key, STATE_ATTACKING, false)
     //call GroupRecycleGuardPositionDelay(harasser,GetTimeToReachLoc(u, home_location) + 1)
     //return
   endif
   call TQAddGroupJob(2, HARASS, ht, target, harasser)
+  set target = null
+  set hu = null
 endfunction
 #ENDIF

--- a/Jobs/HARASS.eai
+++ b/Jobs/HARASS.eai
@@ -105,6 +105,7 @@ function HarassJob takes integer ht, unit targ, group harasser returns nothing
   local unit u = null
   local unit hu = null
   local player p = null
+  local group g = null
   local real strength_sum = 0
   local real player_sum = 0
   local integer harass_num = 0

--- a/Jobs/HEALTH_FOUNTAIN.eai
+++ b/Jobs/HEALTH_FOUNTAIN.eai
@@ -38,7 +38,7 @@ local boolean creepsawake = false
     set fountain = null
     return
   elseif fountain == null then
-    call TQAddUnitJob(2, SEND_HOME, p, u)
+    call TQAddUnitJob(2, SEND_HOME, GetRandomInt(0,Max(exist_town_num-1,0)), u)
     return
   endif
   set x = GetUnitX(fountain)
@@ -51,16 +51,14 @@ local boolean creepsawake = false
   if (distance <= 600 and (detectedenemies >= unitstrengt or creepsawake)) or (difficulty == HARD and (enemiesatfountain >= unitstrengt or creepsawake)) then
 //    call DisplayToAll("Fountain Return Home")
     call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
-    call GroupRemoveUnit(unit_healing, u)
     call TQAddUnitJob(8, RESET_GUARD_POSITION, p, u)
   elseif GetUnitState(u, UNIT_STATE_LIFE) >= GetUnitState(u, UNIT_STATE_MAX_LIFE) * (I2R(p)/100) then
 //    call DisplayToAll("Fountain Healed")
     call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)
-    return
   else
 //    call DisplayToAll("Fountain Move to fountain")
     if distance >= buy_distance then
-      if GetUnitAbilityLevel(u, 'Ashm') > 0 and GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800) > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6) then
+      if GetUnitAbilityLevel(u, 'AIhm') > 0 or (GetUnitAbilityLevel(u, 'Ashm') > 0 and GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800) > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
         call IssueImmediateOrder(u, "ambush")
       else
         if GetUnitCurrentOrder(u) != OrderId("move") then
@@ -69,7 +67,7 @@ local boolean creepsawake = false
       endif
     else
       if IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then  //no need do anything
-      elseif (GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
+      elseif GetUnitAbilityLevel(u, 'AIhm') > 0 or (GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
         call IssueImmediateOrder(u, "ambush")
       else
         if GetUnitCurrentOrder(u) != OrderId("patrol") then

--- a/Jobs/ITEM_EXPANSION.eai
+++ b/Jobs/ITEM_EXPANSION.eai
@@ -54,7 +54,7 @@ function ItemExpansionJob takes nothing returns nothing
     set not_taken_expansion = current_expansion
     if u == null then
       set temp = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), old_id[racial_expansion], GetUnitX(current_expansion), GetUnitY(current_expansion), 270.0)
-      set item_exp_loc = Location(GetUnitX(temp),GetUnitY(temp))
+      set item_exp_loc = GetUnitLoc(temp)
       call RemoveUnit(temp)
       set temp = null
       set loc = GetUnitLoc(current_expansion)
@@ -85,7 +85,7 @@ function ItemExpansionJob takes nothing returns nothing
     call Trace("Expansion state 3: Check Use Item")
     if GetItemOfTypeOnUnit(race_item_expansion_item_id, itemhero) != null and not CheckExpansionTaken (current_expansion) then
       set temp = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), old_id[racial_expansion], GetUnitX(current_expansion), GetUnitY(current_expansion), 270.0)
-      set item_exp_loc = Location(GetUnitX(temp),GetUnitY(temp))
+      set item_exp_loc = GetUnitLoc(temp)
       call RemoveUnit(temp)
       set temp = null
       call RemoveGuardPosition(itemhero)

--- a/Jobs/MANA_FOUNTAIN.eai
+++ b/Jobs/MANA_FOUNTAIN.eai
@@ -39,7 +39,7 @@ local boolean creepsawake = false
     set fountain = null
     return
   elseif fountain == null then
-    call TQAddUnitJob(2, SEND_HOME, p, u)
+    call TQAddUnitJob(2, SEND_HOME, GetRandomInt(0,Max(exist_town_num-1,0)), u)
     return
   endif
   set x = GetUnitX(fountain)
@@ -54,10 +54,9 @@ local boolean creepsawake = false
     call TQAddUnitJob(8, RESET_GUARD_POSITION, p, u)
   elseif GetUnitState(u, UNIT_STATE_MANA) >= GetUnitState(u, UNIT_STATE_MAX_MANA) * (I2R(p)/100) then
     call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)
-    return
   else
     if distance >= buy_distance then
-      if GetUnitAbilityLevel(u, 'Ashm') > 0 and GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800) > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6) then
+      if GetUnitAbilityLevel(u, 'AIhm') > 0 or (GetUnitAbilityLevel(u, 'Ashm') > 0 and GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800) > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
         call IssueImmediateOrder(u, "ambush")
       else
         if GetUnitCurrentOrder(u) != OrderId("move") then
@@ -66,7 +65,7 @@ local boolean creepsawake = false
       endif
     else
       if IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then  //no need do anything
-      elseif (GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
+      elseif GetUnitAbilityLevel(u, 'AIhm') > 0 or (GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) <= 6)) then
         call IssueImmediateOrder(u, "ambush")
       else
         if GetUnitCurrentOrder(u) != OrderId("patrol") then

--- a/Jobs/MICRO_HERO.eai
+++ b/Jobs/MICRO_HERO.eai
@@ -177,7 +177,7 @@ function SaveHero takes integer hn , integer armyOfHero returns nothing
   local unit healer = null
   local integer hFountainID = GetHealthFountainID()
   local integer mFountainID = GetManaFountainID()
-  local location l = Location(GetUnitX(hero_unit[hn]),GetUnitY(hero_unit[hn]))
+  local location l = GetUnitLoc(hero_unit[hn])
   set healer = GetHealer()
   call ActionListInit(9)
 #INCLUDE <HeroFleeRules.ai>
@@ -217,7 +217,7 @@ function MicroHeroJob takes integer hn returns nothing
     endif
     //set hero_dir[hn] = GetSubtractionLoc_dd(GetUnitLoc(hero_unit[hn]), hero_loc[hn])
     set hero_dir[hn] = hero_loc[hn]
-    set hero_loc[hn] = Location(GetUnitX(hero_unit[hn]), GetUnitY(hero_unit[hn]))
+    set hero_loc[hn] = GetUnitLoc(hero_unit[hn])
     set hero_hp_loss[hn] = hero_hp[hn] - new_hp
     set hero_hp[hn] = new_hp
     call GetDensities(hero_loc[hn], ai_player, hero_radius)

--- a/Jobs/MICRO_HERO.eai
+++ b/Jobs/MICRO_HERO.eai
@@ -145,7 +145,7 @@ function ExecuteSaveHero takes integer hn, integer a, unit healer returns nothin
     //call UnitGoHome(hero_unit[hn])
     call CreateDebugTag("HERO: Going Home", 10, hero_unit[hn], 4.00, 2.00)
     call GroupAddUnit(unit_healing, hero_unit[hn])
-    call TQAddUnitJob(0, SEND_HOME, 50, hero_unit[hn])
+    call TQAddUnitJob(0, SEND_HOME, GetRandomInt(0,Max(exist_town_num-1,0)), hero_unit[hn])
   elseif a == ACTION_ZEPPELIN_HOME then
     call CreateDebugTag("HERO: Zeppelin Home", 10, hero_unit[hn], 4.00, 2.00)
     call GroupAddUnit(unit_rescueing, follow_zeppelin)

--- a/Jobs/MICRO_UNITS.eai
+++ b/Jobs/MICRO_UNITS.eai
@@ -168,7 +168,7 @@ function GetMana takes unit u , integer id returns nothing
   local real daytime = GetFloatGameState(GAME_STATE_TIME_OF_DAY)
   local integer mFountainID = GetManaFountainID()
 
-  if race_use_fountain and GetUnitState(u, UNIT_STATE_MANA) < GetUnitState(u, UNIT_STATE_MAX_MANA) * 0.4 and not IsUnitType(u, UNIT_TYPE_PEON) and neutral_enemy[mFountainID] <= 0 and not (id == old_id[racial_ghoul]) and not (id == old_id[racial_militia]) and neutral_available[mFountainID] and nearest_neutral[mFountainID] != null and (not neutral_guarded[mFountainID] or (neutral_night_buy[mFountainID] and (daytime >= 18 or daytime < 6))) then
+  if race_use_fountain and GetUnitState(u, UNIT_STATE_MANA) < GetUnitState(u, UNIT_STATE_MAX_MANA) * 0.4 and neutral_enemy[mFountainID] <= 0 and not (id == old_id[racial_ghoul]) and not (id == old_id[racial_militia]) and neutral_available[mFountainID] and nearest_neutral[mFountainID] != null and (not neutral_guarded[mFountainID] or (neutral_night_buy[mFountainID] and (daytime >= 18 or daytime < 6))) then
     call CreateDebugTag("Going to mana fountain", 10, u, 3.00, 1.50)
     call GroupAddUnit(unit_healing, u)
     call TQAddUnitJob(8, MANA_FOUNTAIN, 80, u)
@@ -226,7 +226,7 @@ function MicroUnitsJob takes nothing returns nothing
           // if deny == true and not IsUnitType(u, UNIT_TYPE_HERO) and unit_life < RMin(0.1 * unit_life_max, 24) then
           //   call DenyUnit(u,id)
           // endif
-          if not IsUnitType(u, UNIT_TYPE_MECHANICAL) and (id == 'hphx' or not IsUnitType(u, UNIT_TYPE_SUMMONED)) and GetUnitFoodUsed(u) > 0 and unit_life < RMax(flee_health_percentage * unit_life_max, flee_minimum_health) then
+          if not IsUnitType(u, UNIT_TYPE_MECHANICAL) and (id == 'hphx' or not IsUnitType(u, UNIT_TYPE_SUMMONED)) and unit_life < RMax(flee_health_percentage * unit_life_max, flee_minimum_health) then
             call SaveUnit(u,id)
           else
             #INCLUDETABLE <$VER$\StandardUnits.txt> #COND "%4" =~ /\bstatue\b/

--- a/Jobs/MICRO_UNITS.eai
+++ b/Jobs/MICRO_UNITS.eai
@@ -23,7 +23,6 @@
 //  if IsUnitType(u, UNIT_TYPE_HERO) then
 //    return
 //  endif
-  
 //  if healer != null and not IsUnitType(u, UNIT_TYPE_MECHANICAL) then
 //    call RemoveGuardPosition(u)
 //    call GroupAddUnit(unit_healing, u)
@@ -32,7 +31,7 @@
 //    call HealUnit(healer, u, true)
 //	call RemoveLocation(unitloc)
 //	set unitloc = null
-//  elseif race_use_fountain and not IsUnitType(u, UNIT_TYPE_PEON) and not IsUnitType(u, UNIT_TYPE_MECHANICAL) and neutral_enemy[NEUTRAL_HEALING_FOUNTAIN] <= 0 and not (GetUnitTypeId(u) == old_id[racial_ghoul]) and not (GetUnitTypeId(u) == old_id[racial_militia]) and neutral_available[NEUTRAL_HEALING_FOUNTAIN] and nearest_neutral[NEUTRAL_HEALING_FOUNTAIN] != null and (not neutral_guarded[NEUTRAL_HEALING_FOUNTAIN] or (neutral_night_buy[NEUTRAL_HEALING_FOUNTAIN] and daytime >= 18 and nearest_neutral[NEUTRAL_HEALING_FOUNTAIN] != null)) then
+//  elseif race_use_fountain and not IsUnitType(u, UNIT_TYPE_PEON) and not IsUnitType(u, UNIT_TYPE_MECHANICAL) and neutral_enemy[NEUTRAL_HEALING_FOUNTAIN] <= 0 and not (id == old_id[racial_ghoul]) and not (id == old_id[racial_militia]) and neutral_available[NEUTRAL_HEALING_FOUNTAIN] and nearest_neutral[NEUTRAL_HEALING_FOUNTAIN] != null and (not neutral_guarded[NEUTRAL_HEALING_FOUNTAIN] or (neutral_night_buy[NEUTRAL_HEALING_FOUNTAIN] and daytime >= 18 and nearest_neutral[NEUTRAL_HEALING_FOUNTAIN] != null)) then
 //      call RemoveGuardPosition(u)
 //    	call GroupAddUnit(unit_healing, u)
 //  //  call TQAddUnitJob(8, RESET_HEALTH, 80, u)
@@ -43,116 +42,138 @@
 
 //============================================================================
 function StatueControl takes unit u returns nothing
-  local location statue_loc = GetProjectedLoc(last_ally_loc, GetSubtractionLoc(last_ally_loc, last_enemy_loc), statue_distance)
-  local location unitloc = GetUnitLoc(u)
-  if DistanceBetweenPoints(unitloc, statue_loc) > 200 then
+  local location loc = GetSubtractionLoc(last_ally_loc, last_enemy_loc)
+  local location statue_loc = GetProjectedLoc(last_ally_loc, loc, statue_distance)
+  if DistanceBetweenPoints_dk(GetUnitLoc(u), statue_loc) > 200 then
     call IssuePointOrderLoc(u, "move", statue_loc)
   endif
+  call RemoveLocation(loc)
+  set loc = null
   call RemoveLocation(statue_loc)
   set statue_loc = null
-  call RemoveLocation(unitloc)
-  set unitloc = null
 endfunction
 
 //============================================================================
-function SaveUnit takes unit u returns nothing
+function DenyUnit takes unit u , integer id returns nothing
+  // if id != 'ugrm' and id != 'ohwd' and not IsUnitType(u, UNIT_TYPE_ETHEREAL) and not IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
+  //   set deny_unit = u
+  // endif
+endfunction
+
+//============================================================================
+function SaveUnit takes unit u , integer id returns nothing
   local real daytime = GetFloatGameState(GAME_STATE_TIME_OF_DAY)
-  local unit healer = GetHealer()
+  local unit healer = null
   local location l = null
   local group g = null
   local location unitloc = null
   local location temploc = null
   local integer hFountainID = GetHealthFountainID()
-  
+  local integer healertepy = 0
+
   if IsUnitType(u, UNIT_TYPE_HERO) then
     return
   endif
-  
-  if (GetUnitTypeId(u) == old_id[racial_militia]) then
-	return
+  if id == 'hphx' or id == old_id[racial_militia] then
+    call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
+    return
   endif
-  
-  call RemoveGuardPosition(u)
-  if not IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
-	call IssueImmediateOrder(u, "windwalk")
+  call RemoveGuardPosition(u)  //no Remove 'hphx'
+  if GetUnitAbilityLevel(u, 'AOwk') > 0 or GetUnitAbilityLevel(u, 'ANwk') > 0 then
+    if not IsUnitInvisible(u, Player(PLAYER_NEUTRAL_AGGRESSIVE)) then
+      call IssueImmediateOrder(u, "windwalk")
+    endif
   endif
+  set healer = GetHealer()
 //  call SetUnitUserData(u, UNIT_GOING_HOME)
-
-  if healer != null and not IsUnitType(u, UNIT_TYPE_MECHANICAL) then
-  	call CreateDebugTag("Going to Healer", 10, u, 3.00, 1.50)	
-  	set unitloc = GetUnitLoc(healer)
-  	if GetLocationX(last_enemy_loc) != 0 and GetLocationY(last_enemy_loc) != 0 then
-  		set l = GetProjectedLoc(unitloc, GetSubtractionLoc(unitloc, last_enemy_loc), 350)
-  		call TQAddUnitJob(GetTimeToReachLoc(u, l) + 1, RESET_GUARD_POSITION, 0, u)
-  		call IssuePointOrderLoc(u, "move", l)	
-  		call RemoveLocation(l)
-  		set l = null		
-  	else
-  		call TQAddUnitJob(GetTimeToReachLoc(u, unitloc) + 1, RESET_GUARD_POSITION, 0, u)
-  		call IssuePointOrderLoc(u, "move", unitloc)				
-  	endif
-    call GroupAddUnit(unit_healing, u)
-  	call RemoveLocation(unitloc)
-  	set unitloc = null
-    call HealUnit(healer, u, false)
-  elseif race_use_fountain and not IsUnitType(u, UNIT_TYPE_PEON) and not IsUnitType(u, UNIT_TYPE_MECHANICAL) and neutral_enemy[hFountainID] <= 0 and not (GetUnitTypeId(u) == old_id[racial_ghoul]) and not (GetUnitTypeId(u) == old_id[racial_militia]) and neutral_available[hFountainID] and nearest_neutral[hFountainID] != null and (not neutral_guarded[hFountainID] or (neutral_night_buy[hFountainID] and daytime >= 18 and nearest_neutral[hFountainID] != null))  then
+  if healer != null then  //and not IsUnitType(u, UNIT_TYPE_MECHANICAL) then  //Repetitive judgment
+    set healertepy = healer_type[GetHealerId(GetUnitTypeId(healer))]
+    if not CaptainInCombat(true) or (healertepy == HEALER_TYPE_NO_TARGET or healertepy == HEALER_TYPE_WARD or GetUnitState(u, UNIT_STATE_LIFE) > GetUnitState(u, UNIT_STATE_MAX_LIFE) * 55) then
+      call CreateDebugTag("Going to Healer", 10, u, 3.00, 1.50)
+      // Captain In Combat , if healer no Immediate and extensive treatment , urgent healing need go home , avoid staying on the battlefield
+      set unitloc = GetUnitLoc(healer)
+      if GetLocationX(last_enemy_loc) != 0 and GetLocationY(last_enemy_loc) != 0 then
+        set temploc = GetSubtractionLoc(unitloc, last_enemy_loc)
+        set l = GetProjectedLoc(unitloc, temploc, 350)
+        call TQAddUnitJob(GetTimeToReachLoc(u, l) + 1, RESET_GUARD_POSITION, 0, u)
+        call IssuePointOrderLoc(u, "move", l)
+        call RemoveLocation(temploc)
+        set temploc = null
+        call RemoveLocation(l)
+        set l = null
+      else
+        call TQAddUnitJob(GetTimeToReachLoc(u, unitloc) + 1, RESET_GUARD_POSITION, 0, u)
+        call IssuePointOrderLoc(u, "move", unitloc)
+      endif
+      call GroupAddUnit(unit_healing, u)
+      call RemoveLocation(unitloc)
+      set unitloc = null
+      call HealUnit(healer, u, false)
+      set healer = null
+      return
+    endif
+  endif
+  if race_use_fountain and neutral_enemy[hFountainID] <= 0 and id != old_id[racial_ghoul] and neutral_available[hFountainID] and nearest_neutral[hFountainID] != null and (not neutral_guarded[hFountainID] or (neutral_night_buy[hFountainID] and (daytime >= 18 or daytime < 6))) then  //not IsUnitType(u, UNIT_TYPE_PEON) and not IsUnitType(u, UNIT_TYPE_MECHANICAL)  //Repetitive judgment
     if follow_zeppelin != null and not IsUnitInGroup(follow_zeppelin, unit_rescueing) and not IsUnitType(u, UNIT_TYPE_FLYING) then
-//      call SetUnitUserData(follow_zeppelin, UNIT_RESCUEING)
-  		call CreateDebugTag("Zepplin to fountain", 10, follow_zeppelin, 3.00, 1.50)
+      //    call SetUnitUserData(follow_zeppelin, UNIT_RESCUEING)
+      call CreateDebugTag("Zepplin to fountain", 10, follow_zeppelin, 3.00, 1.50)
       call GroupAddUnit(unit_rescueing, follow_zeppelin)
       set g = CreateGroup()
       call GroupAddUnit(g, follow_zeppelin)
-  		call GroupAddUnit(unit_healing, u)	  
+      call GroupAddUnit(unit_healing, u)	  
       call TQAddGroupJob(0, ZEPPELIN_MOVE, ZTARGET_FOUNTAIN, u, g)
+      set g = null
     else
-		  call GroupAddUnit(unit_healing, u)
-	  	call CreateDebugTag("Going to Fountain", 10, u, 3.00, 1.50)
-		  call TQAddUnitJob(0, HEALTH_FOUNTAIN, 80, u)
-     	call IssuePointOrder(u, "move", GetUnitX(nearest_neutral[hFountainID]), GetUnitY(nearest_neutral[hFountainID]))  
+      call GroupAddUnit(unit_healing, u)
+      call CreateDebugTag("Going to Fountain", 10, u, 3.00, 1.50)
+      call TQAddUnitJob(0, HEALTH_FOUNTAIN, 80, u)
+      call IssuePointOrder(u, "move", GetUnitX(nearest_neutral[hFountainID]), GetUnitY(nearest_neutral[hFountainID]))
     endif
-  elseif race_has_moonwells and TownCountDone(racial_farm) > 0 and not IsUnitType(u, UNIT_TYPE_SUMMONED) then
+  elseif race_has_moonwells and TownCountDone(racial_farm) > 0 then  //and not IsUnitType(u, UNIT_TYPE_SUMMONED) then  //Repetitive judgment
     if follow_zeppelin != null and not IsUnitInGroup(follow_zeppelin, unit_rescueing) and not IsUnitType(u, UNIT_TYPE_FLYING) then
-  		call GroupAddUnit(unit_rescueing, follow_zeppelin)
-  		call CreateDebugTag("Zeppelin to Moonwells", 10, u, 3.00, 1.50)
-  		set g = CreateGroup()
-  		call GroupAddUnit(g, follow_zeppelin)
-  		call GroupAddUnit(unit_healing, u)	
-  		call TQAddGroupJob(0, ZEPPELIN_MOVE, ZTARGET_MOONWELLS, u, g)		
-  	else
-  		call CreateDebugTag("Going to Moonwells", 10, u, 3.00, 1.50)
-  		call GroupAddUnit(unit_healing, u)
-  		call TQAddUnitJob(0, MOON_WELL_CONTROL, 80, u)
-  	endif
+      call GroupAddUnit(unit_rescueing, follow_zeppelin)
+      call CreateDebugTag("Zeppelin to Moonwells", 10, u, 3.00, 1.50)
+      set g = CreateGroup()
+      call GroupAddUnit(g, follow_zeppelin)
+      call GroupAddUnit(unit_healing, u)
+      call TQAddGroupJob(0, ZEPPELIN_MOVE, ZTARGET_MOONWELLS, u, g)
+      set g = null
+    else
+      call CreateDebugTag("Going to Moonwells", 10, u, 3.00, 1.50)
+      call GroupAddUnit(unit_healing, u)
+      call TQAddUnitJob(0, MOON_WELL_CONTROL, 80, u)
+    endif
   //elseif GetUnitCurrentOrder(u) != OrderId("move") then	
   elseif follow_zeppelin != null and not IsUnitInGroup(follow_zeppelin, unit_rescueing) and not IsUnitType(u, UNIT_TYPE_FLYING) then
-//    call SetUnitUserData(follow_zeppelin, UNIT_RESCUEING)
-	  call CreateDebugTag("Zepplin Home", 10, u, 3.00, 1.50)
+    //    call SetUnitUserData(follow_zeppelin, UNIT_RESCUEING)
+    call CreateDebugTag("Zepplin Home", 10, u, 3.00, 1.50)
     call GroupAddUnit(unit_rescueing, follow_zeppelin)
     set g = CreateGroup()
     call GroupAddUnit(g, follow_zeppelin)
-	  call GroupAddUnit(unit_healing, u)	
-    call TQAddGroupJob(0, ZEPPELIN_MOVE, ZTARGET_HOME, u, g)
-  else
-	  call CreateDebugTag("Going Home", 10, u, 3.00, 1.50)
     call GroupAddUnit(unit_healing, u)
-    call TQAddUnitJob(0, SEND_HOME, 50, u)
+    call TQAddGroupJob(0, ZEPPELIN_MOVE, ZTARGET_HOME, u, g)
+    set g = null
+  else
+    call CreateDebugTag("Going Home", 10, u, 3.00, 1.50)
+    call GroupAddUnit(unit_healing, u)
+    call TQAddUnitJob(0, SEND_HOME, GetRandomInt(0,Max(exist_town_num-1,0)), u)
     //call TQAddUnitJob(GetTimeToReachLoc(u, home_location) + 1, RESET_GUARD_POSITION, 0, u)
-    //call IssuePointOrderLoc(u, "move", home_location)			 
-  
+    //call IssuePointOrderLoc(u, "move", home_location)
   endif
+  set healer = null
 endfunction
 
 //============================================================================
-function GetMana takes unit u returns nothing
-	local real daytime = GetFloatGameState(GAME_STATE_TIME_OF_DAY)
+function GetMana takes unit u , integer id returns nothing
+  local real daytime = GetFloatGameState(GAME_STATE_TIME_OF_DAY)
   local integer mFountainID = GetManaFountainID()
-	
-	if race_use_fountain and GetUnitState(u, UNIT_STATE_MANA) < GetUnitState(u, UNIT_STATE_MAX_MANA) * 0.4 and not IsUnitType(u, UNIT_TYPE_PEON) and neutral_enemy[mFountainID] <= 0 and not (GetUnitTypeId(u) == old_id[racial_ghoul]) and not (GetUnitTypeId(u) == old_id[racial_militia]) and neutral_available[mFountainID] and nearest_neutral[mFountainID] != null and (not neutral_guarded[mFountainID] or (neutral_night_buy[mFountainID] and daytime >= 18 and nearest_neutral[mFountainID] != null)) then
-		call CreateDebugTag("Going to mana fountain", 10, u, 3.00, 1.50)	  
-		call GroupAddUnit(unit_healing, u)
-		call TQAddUnitJob(8, MANA_FOUNTAIN, 80, u)    
-		call IssuePointOrder(u, "move", GetUnitX(nearest_neutral[mFountainID]), GetUnitY(nearest_neutral[mFountainID]))
-	endif
+
+  if race_use_fountain and GetUnitState(u, UNIT_STATE_MANA) < GetUnitState(u, UNIT_STATE_MAX_MANA) * 0.4 and not IsUnitType(u, UNIT_TYPE_PEON) and neutral_enemy[mFountainID] <= 0 and not (id == old_id[racial_ghoul]) and not (id == old_id[racial_militia]) and neutral_available[mFountainID] and nearest_neutral[mFountainID] != null and (not neutral_guarded[mFountainID] or (neutral_night_buy[mFountainID] and (daytime >= 18 or daytime < 6))) then
+    call CreateDebugTag("Going to mana fountain", 10, u, 3.00, 1.50)
+    call GroupAddUnit(unit_healing, u)
+    call TQAddUnitJob(8, MANA_FOUNTAIN, 80, u)
+    call IssuePointOrder(u, "move", GetUnitX(nearest_neutral[mFountainID]), GetUnitY(nearest_neutral[mFountainID]))
+  endif
 endfunction
 
 //============================================================================
@@ -160,115 +181,116 @@ function MicroUnitsJob takes nothing returns nothing
   local group g = CreateGroup()
   local unit u = null
   local real unit_life = 0
+  local real unit_life_max = 0
   local real unit_mana = 0
   local group new_healer_group = CreateGroup()
   local boolean ward_check = false
   local boolean prev_ward = ward_cast
-  local location unitloc = null
-
-  
+  //local boolean deny = (GetGold() > 600 and GetWood() > 400) or GetGoldOwned() > 3000
+  //local location unitloc = null
   local real health_sum = 0.0
   local integer count = 0
   local real unit_health_ratio = 0.0
-
+  local integer id = 0
   if major_hero == null or not UnitAlive(major_hero) then
     set major_hero = GetMajorHero()
   endif
-
   //call DisplayToAllJobDebug("MICRO_UNITS Job Started") 
 
   //call GroupEnumUnitsInRange(g,GetUnitX(major_hero),GetUnitY(major_hero),battle_radius,null)
   call GroupEnumUnitsOfPlayer(g, ai_player, null)
-  set g = SelectByAlive(g, true)  
-  set g = SelectByUnitStandard(g, true)
   set g = SelectUnittype(g,UNIT_TYPE_PEON,false)
   set g = SelectUnittype(g,UNIT_TYPE_STRUCTURE,false)
-  set g = SelectUnittype(g,UNIT_TYPE_SUMMONED,false)
-  //call DisplayToAll("MICRO_UNITS: Group made") 
+  set g = SelectByIllusion(g, false)
+  set g = SelectByUnitStandard(g, true)
+  //set g = SelectUnittype(g,UNIT_TYPE_SUMMONED,false)  // need search 'ohwd' and 'hphx'
+  //call DisplayToAll("MICRO_UNITS: Group made")
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
-	//call DisplayToAllJobDebug("MICRO_UNITS: Main Loop")
     set unit_life = GetUnitState(u, UNIT_STATE_LIFE)
+    set unit_life_max = GetUnitState(u, UNIT_STATE_MAX_LIFE)
     set unit_mana = GetUnitState(u, UNIT_STATE_MANA)
-    set unitloc = GetUnitLoc(u)	
-    //if (attack_running or town_threatened) then //and DistanceBetweenUnits(major_hero, u) <= battle_radius then
-	  //call Trace("MIRCO_UNITS: Attack healing section")
-      //if IsPlayerAlly(GetOwningPlayer(u), ai_player) then
-	    //call Trace("MICRO_UNITS: Friendly Unit")
-        if GetUnitTypeId(u) == 'ohwd' then
-//         	call GroupAddUnit(new_healer_group, u)
-          if GetOwningPlayer(u) == ai_player then
-            set ward_check = true
+    set id = GetUnitTypeId(u)
+    if id == 'ohwd' then
+      //         call GroupAddUnit(new_healer_group, u)
+      set ward_check = true
+    endif
+    if unit_life > 0 then
+      //call DisplayToAllJobDebug("MICRO_UNITS: Main Loop")
+      //set unitloc = GetUnitLoc(u)
+      //if (attack_running or town_threatened) then //and DistanceBetweenUnits(major_hero, u) <= battle_radius then
+        //call Trace("MIRCO_UNITS: Attack healing section")
+        //if IsPlayerAlly(GetOwningPlayer(u), ai_player) then
+          //call Trace("MICRO_UNITS: Friendly Unit")
+          // if deny == true and not IsUnitType(u, UNIT_TYPE_HERO) and unit_life < RMin(0.1 * unit_life_max, 24) then
+          //   call DenyUnit(u,id)
+          // endif
+          if not IsUnitType(u, UNIT_TYPE_MECHANICAL) and (id == 'hphx' or not IsUnitType(u, UNIT_TYPE_SUMMONED)) and GetUnitFoodUsed(u) > 0 and unit_life < RMax(flee_health_percentage * unit_life_max, flee_minimum_health) then
+            call SaveUnit(u,id)
+          else
+            #INCLUDETABLE <$VER$\StandardUnits.txt> #COND "%4" =~ /\bstatue\b/
+            if id == o%1 then
+              //call DisplayToAllJobDebug("MICRO_UNITS: Statue Control")
+              if attack_running and GetLocationX(last_enemy_loc) != 0 and GetLocationY(last_enemy_loc) != 0 then
+                call StatueControl(u)
+              endif
+              //call DisplayToAllJobDebug("MICRO_UNITS: Statue Control end")
+            endif
+            #ENDINCLUDE
+            if IsUnitHealer(u) then
+              call GroupAddUnit(new_healer_group, u)
+            endif
+            //if GetUnitFoodUsed(u) > 0 and unit_mana < RMax(0.35 * GetUnitState(u, UNIT_STATE_MAX_MANA), 50) then
+              //call GetMana(u, id)
+            //endif
           endif
-        endif
-        if not (IsUnitType(u, UNIT_TYPE_MECHANICAL) or IsUnitType(u, UNIT_TYPE_SUMMONED)) and not IsUnitIllusion(u) and GetUnitFoodUsed(u) > 0 and unit_life < RMax(flee_health_percentage * GetUnitState(u, UNIT_STATE_MAX_LIFE), flee_minimum_health) then
-          call SaveUnit(u) 
-        else
-#INCLUDETABLE <$VER$\StandardUnits.txt> #COND "%4" =~ /\bstatue\b/
-        if GetUnitTypeId(u) == o%1 then
-        //call DisplayToAllJobDebug("MICRO_UNITS: Statue Control")
-          if attack_running and GetLocationX(last_enemy_loc) != 0 and GetLocationY(last_enemy_loc) != 0 then
-            call StatueControl(u)
-          endif
-        //call DisplayToAllJobDebug("MICRO_UNITS: Statue Control end")
-        endif
-#ENDINCLUDE
-         if IsUnitHealer(u) then
-          call GroupAddUnit(new_healer_group, u)
-         endif
-              //if GetUnitFoodUsed(u) > 0 and unit_mana < RMax(0.35 * GetUnitState(u, UNIT_STATE_MAX_MANA), 50) then
-            	//call GetMana(u)
-		      //endif
-		endif
-      //else
+          //else
+          //endif
+        //else
+          // HEAL ARMY CODE
+          //INCONSISTENCY  - NOT MODDABLE DETECTED HERE
+          //if id == 'ohwd' then
+            //set ward_cast = true
+          //endif
+          // ///////////////////////////////////
+          //if not (IsUnitType(u, UNIT_TYPE_MECHANICAL)) then
+          //	set unit_health_ratio = unit_life / unit_life_max
+          //	set health_sum = health_sum + unit_health_ratio
+          //	set count = count + 1
+
+
+          //	if GetHealerId(id) != -1 and GetUnitState(u, UNIT_STATE_MANA) >= (healer_mana_cost[GetHealerId(id)] * 2) / 3 and ((healer_upg_id[GetHealerId(id)] == 0) or (GetUpgradeLevel(healer_upg_id[GetHealerId(id)]) >= healer_upg_level[GetHealerId(id)])) then
+            //		call GroupAddUnit(new_healer_group, u)
+          //	endif
+
+          //	if not IsUnitInGroup(u, unit_healing) then
+            //		if unit_life < RMax(flee_health_percentage * unit_life_max, flee_minimum_health) then
+              //		    //call DisplayToAllJobDebug("MICRO_UNITS Special Extra Save")
+              //			call SaveUnit(u,id)
+            //		elseif unit_health_ratio <= 0.5 then
+              //		    //call DisplayToAllJobDebug("MICRO_UNITS Make Unit Heal")
+              //			call MakeUnitHeal(u) 
+            //		endif
+          //	endif
+        //endif
       //endif
-	//else
-		// HEAL ARMY CODE
-		//INCONSISTENCY  - NOT MODDABLE DETECTED HERE
-		//if GetUnitTypeId(u) == 'ohwd' then
-			//set ward_cast = true
-		//endif
-		// ///////////////////////////////////
-		//if not (IsUnitType(u, UNIT_TYPE_MECHANICAL)) then
-		//	set unit_health_ratio = unit_life / GetUnitState(u, UNIT_STATE_MAX_LIFE)
-		//	set health_sum = health_sum + unit_health_ratio
-		//	set count = count + 1
-
-
-		//	if GetHealerId(GetUnitTypeId(u)) != -1 and GetUnitState(u, UNIT_STATE_MANA) >= (healer_mana_cost[GetHealerId(GetUnitTypeId(u))] * 2) / 3 and ((healer_upg_id[GetHealerId(GetUnitTypeId(u))] == 0) or (GetUpgradeLevel(healer_upg_id[GetHealerId(GetUnitTypeId(u))]) >= healer_upg_level[GetHealerId(GetUnitTypeId(u))])) then
-		//		call GroupAddUnit(new_healer_group, u)
-		//	endif	
-		
-		//	if not IsUnitInGroup(u, unit_healing) then
-		//		if unit_life < RMax(flee_health_percentage * GetUnitState(u, UNIT_STATE_MAX_LIFE), flee_minimum_health) then
-		//		    //call DisplayToAllJobDebug("MICRO_UNITS Special Extra Save")
-		//			call SaveUnit(u)
-		//		elseif unit_health_ratio <= 0.5 then
-		//		    //call DisplayToAllJobDebug("MICRO_UNITS Make Unit Heal")
-		//			call MakeUnitHeal(u) 
-		//		endif
-		//	endif
-		//endif		
-	//endif
-		
+    endif
     call GroupRemoveUnit(g,u)
-	call RemoveLocation(unitloc)
-	set unitloc = null
+    //call RemoveLocation(unitloc)
   endloop
-  call DestroyGroup(g)
-  set g = null
- 
+  //set unitloc = null
+
   //call DisplayToAll("MICRO_UNITS: Clear up code")
   if prev_ward or not ward_cast then
     set ward_cast = ward_check
   endif
+
   call DestroyGroup(healer_group)
   set healer_group = new_healer_group
   set new_healer_group = null
-
-//endif
-
+  call DestroyGroup(g)
+  set g = null
   call TQAddJob(1 * sleep_multiplier, MICRO_UNITS, 0)
   //call DisplayToAll("MICRO_UNITS END")
 

--- a/Jobs/MOON_WELL_CONTROL.eai
+++ b/Jobs/MOON_WELL_CONTROL.eai
@@ -3,24 +3,23 @@
 
 #ELSE
 
-function GetMoonWell takes player p, integer id returns unit
-   local unit u = null
-   local group g = CreateGroup()     
-   call GroupEnumUnitsOfPlayer(g, p, null)
-   set g = SelectByAlive(g, true)
-   loop
-     set u = FirstOfGroup(g)
-     exitwhen u == null
-     if GetUnitTypeId(u) == id and GetUnitState(u, UNIT_STATE_MANA) >= 30 then
-       call DestroyGroup(g)
-       set g = null
-       return u
-     endif
-     call GroupRemoveUnit(g, u )
-   endloop
-   call DestroyGroup(g)
-   set g = null
-   return null
+function GetMoonWell takes unit u, player p, integer id returns unit
+  local group g = CreateGroup()
+  call GroupEnumUnitsOfPlayer(g, p, null)
+  set g = SelectByAlive(g, true)
+  loop
+    set u = FirstOfGroup(g)
+    exitwhen u == null
+    if GetUnitTypeId(u) == id and GetUnitState(u, UNIT_STATE_MANA) >= 30 then
+      call DestroyGroup(g)
+      set g = null
+      return u
+    endif
+    call GroupRemoveUnit(g, u)
+  endloop
+  call DestroyGroup(g)
+  set g = null
+  return u
 
 endfunction
 
@@ -32,18 +31,15 @@ function HeadtoMoonWell takes unit u, integer p returns nothing
     if dist >= 1000 and enemystrength > 0 and ((GetUnitState(u, UNIT_STATE_MANA) > 50 and GetUnitAbilityLevel(u, 'AEbl') >= 1) or (GetUnitState(u, UNIT_STATE_MANA) > 10 and GetUnitAbilityLevel(u, 'AEbl') > 1)) then
         call IssuePointOrder(u, "blink", GetUnitX(nearest_moon_well), GetUnitY(nearest_moon_well))
         call IssuePointOrder(u, "smart", GetUnitX(nearest_moon_well), GetUnitY(nearest_moon_well))
-        call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)
     elseif dist >= 1000 and GetUnitAbilityLevel(u, 'Ashm') > 0 and enemystrength > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
         call IssueImmediateOrder(u, "ambush")
-        call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)				
     else
       call IssuePointOrder(u, "smart", GetUnitX(nearest_moon_well), GetUnitY(nearest_moon_well))
-      call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)
     endif
+    call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)
 endfunction
 
 function MoonWellJob takes unit u, integer p returns nothing
-  local location l = null
   local real dist = 0
   local real enemystrength = 0
 
@@ -52,19 +48,17 @@ function MoonWellJob takes unit u, integer p returns nothing
     call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)
     return
   elseif GetUnitState(u, UNIT_STATE_LIFE) >= GetUnitState(u, UNIT_STATE_MAX_LIFE) * (I2R(p)/100) or IsUnitType(u, UNIT_TYPE_SUMMONED) then
-    call GroupRemoveUnit(unit_healing, u)
     call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)
     return
   elseif nearest_moon_well == null or GetUnitState(nearest_moon_well, UNIT_STATE_MANA) < 30 then
-    set nearest_moon_well = GetMoonWell(ai_player, old_id[racial_farm])
-    if nearest_moon_well == null then	  
-        set l = GetUnitLoc(u)
-        set dist = DistanceBetweenPoints(l, home_location)
+    set nearest_moon_well = GetMoonWell(nearest_moon_well, ai_player, old_id[racial_farm])
+    if nearest_moon_well == null then
+        set dist = DistanceBetweenPoints_dk(GetUnitLoc(u), home_location)
         set enemystrength = GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800)
         if dist >= 1000 and enemystrength > 0 and ((GetUnitState(u, UNIT_STATE_MANA) > 50 and GetUnitAbilityLevel(u, 'AEbl') == 1) or (GetUnitState(u, UNIT_STATE_MANA) > 10 and GetUnitAbilityLevel(u, 'AEbl') > 1)) then
             call IssuePointOrder(u, "blink", GetLocationX(home_location), GetLocationY(home_location))
             call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
-            call TQAddUnitJob(2, SEND_HOME, p, u)
+            call TQAddUnitJob(2, SEND_HOME, 0, u)  // 0 is home_location
         elseif dist >= 1000 and enemystrength > 0 and GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
             call IssueImmediateOrder(u, "ambush")
             call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)
@@ -72,12 +66,10 @@ function MoonWellJob takes unit u, integer p returns nothing
             call IssuePointOrder(u, "move", GetLocationX(home_location), GetLocationY(home_location))
             call TQAddUnitJob(4, MOON_WELL_CONTROL, p, u)
         elseif IsUnitType(u,UNIT_TYPE_HERO)==true then
-          call TQAddUnitJob(2, SEND_HOME, p, u)
+          call TQAddUnitJob(2, SEND_HOME, 0, u)  // 0 is home_location
         else
           call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)
         endif
-        call RemoveLocation(l)
-        set l = null
     else
       call HeadtoMoonWell(u, p)
     endif

--- a/Jobs/SEND_HOME.eai
+++ b/Jobs/SEND_HOME.eai
@@ -1,160 +1,162 @@
 #IFDEF GLOBAL
 #ELSE
 
-function SendHomeMoveUnitToLoc takes unit u, integer p, location l returns nothing
-local integer enemystrength = GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800)
+function SendHomeMoveUnitToLoc takes unit u, location l returns nothing
+	local integer enemystrength = GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800)
+	if (GetUnitAbilityLevel(u, 'AOwk') > 0 or GetUnitAbilityLevel(u, 'ANwk') > 0) then
 		if enemystrength > 0 and not UnitInvis(u) then
 			call IssueImmediateOrder(u, "windwalk")
 		endif
-		if enemystrength > 0 and ((GetUnitState(u, UNIT_STATE_MANA) > 50 and GetUnitAbilityLevel(u, 'AEbl') == 1) or (GetUnitState(u, UNIT_STATE_MANA) > 10 and GetUnitAbilityLevel(u, 'AEbl') > 1)) then
-			call IssuePointOrder(u, "blink", GetLocationX(l), GetLocationY(l))
-			call IssuePointOrder(u, "move", GetLocationX(l), GetLocationY(l))
-		elseif GetUnitAbilityLevel(u, 'Ashm') > 0 and enemystrength > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
-			call CreateDebugTag("SEND_HOME: Night Hide", 10, u, 3.00, 1.50)
-			call IssueImmediateOrder(u, "ambush")
-		else
-			call CreateDebugTag("SEND_HOME: Moving to Location", 10, u, 3.00, 2.00)		
-			call RemoveGuardPosition(u)			
-			call IssuePointOrder(u, "move", GetLocationX(l), GetLocationY(l))
-		endif
-		call TQAddUnitJob(4, SEND_HOME, p, u)
+	endif
+	if enemystrength > 0 and ((GetUnitState(u, UNIT_STATE_MANA) > 50 and GetUnitAbilityLevel(u, 'AEbl') == 1) or (GetUnitState(u, UNIT_STATE_MANA) > 10 and GetUnitAbilityLevel(u, 'AEbl') > 1)) then
+		call IssuePointOrder(u, "blink", GetLocationX(l), GetLocationY(l))
+		call IssuePointOrder(u, "move", GetLocationX(l), GetLocationY(l))
+	elseif GetUnitAbilityLevel(u, 'Ashm') > 0 and enemystrength > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
+		call CreateDebugTag("SEND_HOME: Night Hide", 10, u, 3.00, 1.50)
+		call IssueImmediateOrder(u, "ambush")
+	else
+		call CreateDebugTag("SEND_HOME: Moving to Location", 10, u, 3.00, 2.00)
+		//call RemoveGuardPosition(u)
+		call IssuePointOrder(u, "move", GetLocationX(l), GetLocationY(l))
+	endif
 endfunction
-		
-function SomeUnitHasHealingItem takes unit u, integer rhi returns unit
+
+function SomeUnitHasHealingItem takes unit ru, unit u, integer rhi returns unit
 	local group g = CreateGroup()
-	local unit aunit = null
-	
 	call GroupEnumUnitsInRange(g, GetUnitX(u), GetUnitY(u), 400, null)
 	set g = SelectByPlayer(g,ai_player, true)
 	set g = SelectByAlive(g,true)
 	loop
-		set aunit = FirstOfGroup(g)
-		exitwhen aunit == null
-		if rhi != 0 and GetItemNumberOnUnit(rhi, aunit) > 0 then
+		set ru = FirstOfGroup(g)
+		exitwhen ru == null
+		if GetItemNumberOnUnit(rhi, ru) > 0 then
 			call DestroyGroup(g)
 			set g = null
-			return aunit
+			return ru
 		endif
-		call GroupRemoveUnit(g, aunit)
+		call GroupRemoveUnit(g, ru)
 	endloop
 	call DestroyGroup(g)
 	set g = null
 	return null
-endfunction		
-		
+endfunction
+
 function SendUnitHomeJob takes unit u, integer p returns nothing
 
-local location l = null
-local unit nearshopunit = null 
-local group g = null
-local unit corpse = null
-local integer racial_healing_item = GetHeroHealingItem()
-local integer racial_mana_item = GetHeroManaItem()
-local integer enemystrength = 0
-local unit otherhero =null 
-local item it = null
+  local location l = null
+  local unit nearshopunit = null 
+  local group g = null
+  local unit corpse = null
+  local integer racial_healing_item = GetHeroHealingItem()
+  local integer racial_mana_item = GetHeroManaItem()
+  local integer enemystrength = 0
+  local unit otherhero = null
+  local item it = null
 
   call DisplayToAllJobDebug("SEND_HOME Job")
-  if racial_healing_item != null and IsUnitType(u, UNIT_TYPE_HERO) then
-	set otherhero = SomeUnitHasHealingItem(u, racial_healing_item)
-  endif
-	
+
   if IsUnitType(u, UNIT_TYPE_HERO) then
-  	//set shop_wanted = 1
-  	if buy_type[racial_healing_item] == BT_RACIAL_ITEM then
-    	//	set shop_unit = GetUnitOfTypeNearUnit(old_id[racial_shop], u)
-    		set nearshopunit = GetUnitOfTypeNearUnit(old_id[racial_shop], u)
-    	//	set shop_distance_limit = raceshop_distance_limit
-  	else
-    	//	set shop_unit = nearest_neutral[NEUTRAL_MERCHANT]
-		    if not (neutral_guarded[NEUTRAL_MERCHANT] and ((GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 5 and GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 18) or not neutral_night_buy[NEUTRAL_MERCHANT])) then
-				set nearshopunit = nearest_neutral[NEUTRAL_MERCHANT]
-			endif
-    	//	set shop_distance_limit = merchant_distance_limit
-  	endif
-  	//set shop_sent = u
-      //call TQAddJob(0, BUY_ITEM, racial_healing_item)
-      //set nearshopunit = shop_unit
+    if racial_healing_item != 0 then
+      set otherhero = SomeUnitHasHealingItem(otherhero, u, racial_healing_item)
+    endif
+    //set shop_wanted = 1
+    if buy_type[racial_healing_item] == BT_RACIAL_ITEM then
+      //set shop_unit = GetUnitOfTypeNearUnit(old_id[racial_shop], u)
+      set nearshopunit = GetUnitOfTypeNearUnit(old_id[racial_shop], u)
+      //	set shop_distance_limit = raceshop_distance_limit
+    else
+      //	set shop_unit = nearest_neutral[NEUTRAL_MERCHANT]
+      if not (neutral_guarded[NEUTRAL_MERCHANT] and ((GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 5 and GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 18) or not neutral_night_buy[NEUTRAL_MERCHANT])) then
+        set nearshopunit = nearest_neutral[NEUTRAL_MERCHANT]
+      endif
+      //	set shop_distance_limit = merchant_distance_limit
+    endif
+    //set shop_sent = u
+    //call TQAddJob(0, BUY_ITEM, racial_healing_item)
+    //set nearshopunit = shop_unit
   endif
 
   call DisplayToAllJobDebug("SEND_HOME Starting check")
 
-   
   // set enemystrength = GetLocationNonCreepStrength(GetUnitX(u), GetUnitY(u), 800)
   if GetUnitState(u, UNIT_STATE_LIFE) <= 0 then
-	call CreateDebugTag("SEND_HOME unit dead", 10, u, 3.00, 1.50)
-  	call GroupRemoveUnit(unit_healing, u)
+    call CreateDebugTag("SEND_HOME unit dead", 10, u, 3.00, 1.50)
     call TQAddUnitJob(2, RESET_GUARD_POSITION, p, u)  
-  elseif GetUnitState(u, UNIT_STATE_LIFE) >= GetUnitState(u, UNIT_STATE_MAX_LIFE) * (I2R(p)/100) and GetUnitCurrentOrder(u) != OrderId("cannibalize") then
-	call CreateDebugTag("SEND_HOME Healed", 10, u, 3.00, 1.50)	
-	call GroupRemoveUnit(unit_healing, u)
+  elseif GetUnitState(u, UNIT_STATE_LIFE) >= GetUnitState(u, UNIT_STATE_MAX_LIFE) * (I2R(60)/100) and GetUnitCurrentOrder(u) != OrderId("cannibalize") then
+    call CreateDebugTag("SEND_HOME Healed", 10, u, 3.00, 1.50)	
     call TQAddUnitJob(2, RESET_GUARD_POSITION, 0, u)
   elseif racial_healing_item != 0 and GetItemNumberOnUnit(racial_healing_item, u) > 0 then
-        set l = GetUnitLoc(u)
-		if GetItemInstantType(racial_healing_item) == ITEMTYPE_CONTINUOUS and DistanceBetweenPoints(l, home_location) >= 1200 then
-			call SendHomeMoveUnitToLoc(u,p,home_location)  // This should be required for all regenerative type healing items	
-		else
-		    set it = GetItemOfTypeOnUnit(racial_healing_item, u)
-			call UnitUseItem(u, it )
-			call UnitUseItemTarget(u, it, u)
-			if racial_mana_item != 0 and GetUnitState(u, UNIT_STATE_MANA) < 100 and GetItemNumberOnUnit(racial_mana_item, u) > 0 then
-				call UnitUseItem(u, GetItemOfTypeOnUnit(racial_mana_item, u))
-			endif
-			call CreateDebugTag("Hero: Use healing item", 10, u, 3.00, 2.00)	
-			call TQAddUnitJob(Max(3,GetItemHealingTime(racial_healing_item)), SEND_HOME, p, u) // Have to add delay as continous healing items run out then
-		endif
-		call RemoveLocation(l)
-		set l = null
-  elseif otherhero != null then
-		call UnitAddItem(u, GetItemOfTypeOnUnit(racial_healing_item, otherhero))
-  elseif nearshopunit != null and GetSlotsFreeOnUnit(u) > 0 and GetItemNumberOnUnit(racial_healing_item, u) <= 0 then
-    set l = GetUnitLoc(nearshopunit)
-	if DistanceBetweenUnits(u, nearshopunit) >= buy_distance then
-		call SendHomeMoveUnitToLoc(u,p, l)
-  	else
-		call CreateDebugTag("SEND_HOME Stop at Shop", 10, u, 3.00, 2.00)	
-      	call IssueImmediateOrder(u, "stop")
-      	call IssueNeutralImmediateOrderById(ai_player, nearshopunit, old_id[racial_healing_item])
-		if GetUnitState(u, UNIT_STATE_MANA) < 100 and GetItemNumberOnUnit(racial_mana_item, u) <= 0 then
-			call IssueNeutralImmediateOrderById(ai_player, nearshopunit, old_id[racial_mana_item])
-		endif
-		call RecycleGuardPosition(u)		
-		call TQAddUnitJob(4, SEND_HOME, p, u)	
-  	endif
-	call RemoveLocation(l)
-  	set l = null
+    call CreateDebugTag("Hero: Use healing item", 10, u, 3.00, 2.00)
+    if GetItemInstantType(racial_healing_item) == ITEMTYPE_CONTINUOUS and DistanceBetweenPoints_dk(GetUnitLoc(u), exist_town[p]) >= 1200 then
+      call SendHomeMoveUnitToLoc(u,exist_town[p])  // This should be required for all regenerative type healing items
+      call TQAddUnitJob(4, SEND_HOME, p, u)
+    else
+      call CreateDebugTag("Hero: Use healing item", 10, u, 3.00, 1.50)
+      set it = GetItemOfTypeOnUnit(racial_healing_item, u)
+      call UnitUseItem(u, it )
+      call UnitUseItemTarget(u, it, u)
+      if racial_mana_item != 0 and GetUnitState(u, UNIT_STATE_MANA) < 100 and GetItemNumberOnUnit(racial_mana_item, u) > 0 then
+        call UnitUseItem(u, GetItemOfTypeOnUnit(racial_mana_item, u))
+      endif
+      call TQAddUnitJob(Max(3,GetItemHealingTime(racial_healing_item)), SEND_HOME, p, u) // Have to add delay as continous healing items run out
+      set it = null
+    endif
+  elseif otherhero != null and IsUnitType(u, UNIT_TYPE_HERO) then
+      if GetSlotsFreeOnUnit(u) > 0 then  // prevent create on the ground
+        call UnitAddItem(u, GetItemOfTypeOnUnit(racial_healing_item, otherhero))
+        call TQAddUnitJob(2, RESET_GUARD_POSITION, 0, u)
+      else
+        call TQAddUnitJob(4, SEND_HOME, p, u)
+      endif
+  elseif nearshopunit != null and IsUnitType(u, UNIT_TYPE_HERO) and GetSlotsFreeOnUnit(u) > 0 and GetItemNumberOnUnit(racial_healing_item, u) <= 0 then
+      if DistanceBetweenUnits(u, nearshopunit) >= buy_distance then
+        set l = GetUnitLoc(nearshopunit)
+        call SendHomeMoveUnitToLoc(u,l)
+        call RemoveLocation(l)
+        set l = null
+        call TQAddUnitJob(4, SEND_HOME, p, u)
+      else
+        call CreateDebugTag("SEND_HOME Stop at Shop", 10, u, 3.00, 2.00)	
+        call IssueImmediateOrder(u, "stop")
+        call IssueNeutralImmediateOrderById(ai_player, nearshopunit, old_id[racial_healing_item])
+        if GetUnitState(u, UNIT_STATE_MANA) < 100 and GetItemNumberOnUnit(racial_mana_item, u) <= 0 then
+          call IssueNeutralImmediateOrderById(ai_player, nearshopunit, old_id[racial_mana_item])
+        endif
+        call TQAddUnitJob(2, RESET_GUARD_POSITION, 0, u)  // end job
+        //call RecycleGuardPosition(u)
+      endif
   else
-      set l = GetUnitLoc(u)
-      if DistanceBetweenPoints(l, home_location) >= 1200 then
-		call SendHomeMoveUnitToLoc(u,p,home_location)
-	  else
-		set g = CreateGroup()
-		call GroupEnumUnitsInRangeOfLoc(g, home_location, 1000, null)
-		set g = SelectByAlive(g, false)		
-		set g = SelectUnittype(g,UNIT_TYPE_STRUCTURE,false)
-		set g = SelectUnittype(g,UNIT_TYPE_DEAD,true)
-		
-		set corpse = FirstOfGroup(g)
-		if town_threatened then
-			call RecycleGuardPosition(u)   // Gives unit control for only a little bit but dosn't remove from healing group
-		elseif GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
-			call IssueImmediateOrder(u, "ambush")
-			call CreateDebugTag("SEND_HOME hide", 10, u, 3.00, 1.50)	
-		elseif GetUnitCurrentOrder(u) != OrderId("cannibalize") and (GetUnitAbilityLevel(u, 'Acn2') > 0 or GetUnitAbilityLevel(u, 'Acan') > 0 or GetUnitAbilityLevel(u, 'ACcn') > 0)  and corpse != null then
-			call IssueTargetOrder(u, "move" , corpse)
-			call IssueImmediateOrder(u, "cannibalize")
-			call CreateDebugTag("SEND_HOME cannibalize", 10, u, 3.00, 1.50)	
-		elseif GetUnitAbilityLevel(u, 'Ahrl') > 0 and GetUnitCurrentOrder(u) != OrderId("cannibalize") then   // 'Ahrl' Ghoul Harvest lumber ability
-			call IssueImmediateOrder(u, "autoharvestlumber")
-			call CreateDebugTag("SEND_HOME harvest lumber", 10, u, 3.00, 1.50)	
-		endif
-		call DestroyGroup(g)
-		set g = null
-		call TQAddUnitJob(4, SEND_HOME, p, u)
-	  endif
-      call RemoveLocation(l)
-	  set l = null
-	  //call DisplayToAllJobDebug("SEND_HOME: JOB Finished!!!! ")
+      if DistanceBetweenPoints_dk(GetUnitLoc(u), exist_town[p]) >= 1200 then
+       call SendHomeMoveUnitToLoc(u,exist_town[p])
+      else
+        set g = CreateGroup()
+        call GroupEnumUnitsInRangeOfLoc(g, exist_town[p], 1000, null)
+        set g = SelectByAlive(g, false)
+        set g = SelectUnittype(g,UNIT_TYPE_STRUCTURE,false)
+        set g = SelectUnittype(g,UNIT_TYPE_DEAD,true)
+        set corpse = FirstOfGroup(g)
+        call DestroyGroup(g)
+        set g = null
+        if town_threatened then
+          call CreateDebugTag("SEND_HOME town_threatened", 10, u, 3.00, 1.50)
+          call RecycleGuardPosition(u)   // Gives unit control for only a little bit but dosn't remove from healing group
+        elseif GetUnitAbilityLevel(u, 'Ashm') > 0 and (GetFloatGameState(GAME_STATE_TIME_OF_DAY) >= 18 or GetFloatGameState(GAME_STATE_TIME_OF_DAY) < 6) and not IsUnitType(u, UNIT_TYPE_HERO) then
+          call IssueImmediateOrder(u, "ambush")
+          call CreateDebugTag("SEND_HOME hide", 10, u, 3.00, 1.50)
+        elseif GetUnitCurrentOrder(u) != OrderId("cannibalize") and (GetUnitAbilityLevel(u, 'Acn2') > 0 or GetUnitAbilityLevel(u, 'Acan') > 0 or GetUnitAbilityLevel(u, 'ACcn') > 0)  and corpse != null then
+          call IssueTargetOrder(u, "move" , corpse)
+          call IssueImmediateOrder(u, "cannibalize")
+          call CreateDebugTag("SEND_HOME cannibalize", 10, u, 3.00, 1.50)
+        elseif GetUnitAbilityLevel(u, 'Ahrl') > 0 and GetUnitCurrentOrder(u) != OrderId("cannibalize") then   // 'Ahrl' Ghoul Harvest lumber ability
+          call IssueImmediateOrder(u, "autoharvestlumber")
+          call CreateDebugTag("SEND_HOME harvest lumber", 10, u, 3.00, 1.50)
+        endif
+      endif
+      call TQAddUnitJob(4, SEND_HOME, p, u)
+      //call DisplayToAllJobDebug("SEND_HOME: JOB Finished!!!! ")
   endif
+  set nearshopunit = null
+  set otherhero = null
+  set corpse = null
 endfunction
 #ENDIF

--- a/Jobs/ZEPPELIN_FOLLOW.eai
+++ b/Jobs/ZEPPELIN_FOLLOW.eai
@@ -18,7 +18,7 @@ function ZeppelinFollowJob takes nothing returns nothing
   if water_expansion_list_length == 0 or racial_lumber != 0 or not race_no_wood_harvest then
     call GroupRemoveGuardPositionInstant(g)  //water_expansion Transport Harvest peon , AI default Transport Order need use zep , racial_lumber help ELF fix building blockage
   endif
-  call GroupPointOrderLoc(g, "attack", home_location)
+  call GroupPointOrderLoc(g, "attack", exist_town[GetRandomInt(0,Max(exist_town_num-1,0))])
   if major_hero != null and UnitAlive(major_hero) then
     set heroloc = GetUnitLoc(major_hero)
     set follow_zeppelin = GetNearestOfGroup(g, heroloc)

--- a/Jobs/ZEPPELIN_FOLLOW.eai
+++ b/Jobs/ZEPPELIN_FOLLOW.eai
@@ -45,7 +45,7 @@ function ZeppelinFollowJob takes nothing returns nothing
     call TQAddJob(RMax((dist - max_follow_dist) / RMax(GetUnitMoveSpeed(follow_zeppelin) + GetUnitMoveSpeed(major_hero), 50), 1) * sleep_multiplier,ZEPPELIN_FOLLOW,0)
   else
     call IssueImmediateOrder(follow_zeppelin, "stop")
-    set l = Location(GetUnitX(follow_zeppelin), GetUnitY(follow_zeppelin))
+    set l = GetUnitLoc(follow_zeppelin)
     set b = IssuePointOrder(follow_zeppelin, "unloadall", GetUnitX(follow_zeppelin), GetUnitY(follow_zeppelin))
     call TQAddJob(10 * sleep_multiplier,ZEPPELIN_FOLLOW,0)
   endif

--- a/Jobs/ZEPPELIN_MOVE.eai
+++ b/Jobs/ZEPPELIN_MOVE.eai
@@ -53,8 +53,8 @@ function ZeppelinMoveJob takes integer target, unit hu, group z returns nothing
     set zepdropping = false
     return
   endif
-  set zeploc = Location(GetUnitX(zep),GetUnitY(zep))
-  set heroloc = Location(GetUnitX(hu),GetUnitY(hu))
+  set zeploc = GetUnitLoc(zep)
+  set heroloc = GetUnitLoc(hu)
   set tl = GetZTargetLocation(target)
   if IsUnitInTransport(hu, zep) then
     if DistanceBetweenPoints(zeploc, tl) > 1000 and not zepdropping then  // and DistanceBetweenPoints(zeploc, ally_loc) < 1500 then

--- a/Jobs/ZEPPELIN_MOVE.eai
+++ b/Jobs/ZEPPELIN_MOVE.eai
@@ -26,7 +26,7 @@ function AddZepFinishingJob takes integer target, integer wait, unit hu returns 
   elseif target == ZTARGET_MOONWELLS then
     call TQAddUnitJob(wait, MOON_WELL_CONTROL, 80, hu)
   else
-    call TQAddUnitJob(wait, SEND_HOME, 50, hu)
+    call TQAddUnitJob(wait, SEND_HOME, GetRandomInt(0,Max(exist_town_num-1,0)), hu)  // 0 is home_location
   endif
 endfunction
 
@@ -37,7 +37,9 @@ function ZeppelinMoveJob takes integer target, unit hu, group z returns nothing
   local location heroloc = null
   local integer clearvars = 0  //=1.. Zepplin system can now finish so return
   if GetUnitState(hu, UNIT_STATE_LIFE) <= 0 then
-    call TQAddUnitJob(2, RESET_GUARD_POSITION, 80, zep)
+    call GroupRemoveUnit(unit_rescueing, zep)
+    call GroupRemoveUnit(unit_zepplin_move, zep)
+    call RecycleGuardPosition(zep)
     call TQAddUnitJob(2, RESET_GUARD_POSITION, 80, hu)
     call DestroyGroup(z)
     set zep = null
@@ -46,7 +48,8 @@ function ZeppelinMoveJob takes integer target, unit hu, group z returns nothing
   endif
   call DisplayToAllJobDebug("ZEPPELIN_MOVE Start")
   if not UnitAlive(zep) then
-    call TQAddUnitJob(2, RESET_GUARD_POSITION, 80, zep)
+    call GroupRemoveUnit(unit_rescueing, zep)
+    call GroupRemoveUnit(unit_zepplin_move, zep)
     call AddZepFinishingJob(target, 1,hu)
     call DestroyGroup(z)
     set zep = null
@@ -90,7 +93,9 @@ function ZeppelinMoveJob takes integer target, unit hu, group z returns nothing
   call RemoveLocation(heroloc)
   set heroloc = null
   if clearvars == 1 then
-    call TQAddUnitJob(2, RESET_GUARD_POSITION, 80, zep)
+    call GroupRemoveUnit(unit_rescueing, zep)
+    call GroupRemoveUnit(unit_zepplin_move, zep)
+    call RecycleGuardPosition(zep)
     set zep = null
     call DestroyGroup(z)
     set zepdropping = false

--- a/Languages/Russian/Strengths.txt
+++ b/Languages/Russian/Strengths.txt
@@ -3,7 +3,7 @@ air	воздух
 casters	кастеры
 towers	башни
 piercing	пирсинг
-normal	нормальный
+normal	нормал
 siege	осадная
 magic	магия
 unarmored	без брони

--- a/MakeAll.bat
+++ b/MakeAll.bat
@@ -1,2 +1,2 @@
-@call MakeTFT
 @call MakeRoC
+@call MakeTFT

--- a/Optimize.bat
+++ b/Optimize.bat
@@ -1,2 +1,2 @@
-@call MakeOptTFT.bat
 @call MakeOptROC.bat
+@call MakeOptTFT.bat

--- a/Optimize.bat
+++ b/Optimize.bat
@@ -1,20 +1,2 @@
-@ECHO OFF
-perl Optimize.pl Scripts\TFT\common.ai Scripts\TFT\elf.ai Scripts\TFT\human.ai Scripts\TFT\orc.ai Scripts\TFT\undead.ai
-pjass common.j Scripts\TFT\common.ai
-pjass common.j Scripts\TFT\common.ai Scripts\TFT\elf.ai
-pjass common.j Scripts\TFT\common.ai Scripts\TFT\human.ai
-pjass common.j Scripts\TFT\common.ai Scripts\TFT\orc.ai
-pjass common.j Scripts\TFT\common.ai Scripts\TFT\undead.ai
-copy TFT_SEMPQ.exe Scripts\TFT\AMAI_TFT.exe
-AddToMPQ Scripts\TFT\AMAI_TFT.exe Scripts\TFT\common.ai Scripts\common.ai Scripts\Blizzard.j Scripts\Blizzard.j
-AddToMPQ Scripts\TFT\AMAI_TFT.exe Scripts\TFT\elf.ai Scripts\elf.ai
-AddToMPQ Scripts\TFT\AMAI_TFT.exe Scripts\TFT\human.ai Scripts\human.ai
-AddToMPQ Scripts\TFT\AMAI_TFT.exe Scripts\TFT\orc.ai Scripts\orc.ai
-AddToMPQ Scripts\TFT\AMAI_TFT.exe Scripts\TFT\undead.ai Scripts\undead.ai
-perl Optimize.pl Scripts\RoC\common.ai Scripts\RoC\elf.ai Scripts\RoC\human.ai Scripts\RoC\orc.ai Scripts\RoC\undead.ai
-pjass common.j Scripts\RoC\common.ai
-pjass common.j Scripts\RoC\common.ai Scripts\RoC\elf.ai
-pjass common.j Scripts\RoC\common.ai Scripts\RoC\human.ai
-pjass common.j Scripts\RoC\common.ai Scripts\RoC\orc.ai
-pjass common.j Scripts\RoC\common.ai Scripts\RoC\undead.ai
-pause
+@call MakeOptTFT.bat
+@call MakeOptROC.bat

--- a/common.eai
+++ b/common.eai
@@ -9127,7 +9127,7 @@ function RemoveHarass takes nothing returns nothing
  loop
    set harass_size[i] = 0
    set i = i + 1
-   exitwhen i == 5
+   exitwhen i >= 5
  endloop
 endfunction
 

--- a/common.eai
+++ b/common.eai
@@ -7219,10 +7219,10 @@ function PathingThread takes nothing returns nothing
   local integer i = 0
   local integer t = 0
   call SetAIArray()
-//  set command_wait = 0.5
-//  set command_wait = 3
+  //  set command_wait = 0.5
+  //  set command_wait = 3
   call ComputeFrontPoints()
-//  call Sleep(3)
+  //  call Sleep(3)
   if debugging then
      call PingFrontPoints()
   endif

--- a/common.eai
+++ b/common.eai
@@ -4133,7 +4133,7 @@ endfunction
 // endfunction
 
 function CreatePathingUnitFull takes unit u, player p, integer id, real x, real y returns unit
-  set u = CreateUnit(ai_player, id, x, y, 270.00) 
+  set u = CreateUnit(p, id, x, y, 270.00) 
   call SetUnitInvulnerable(u, true)
   if (not debugging) then
     call ShowUnit(u, false)

--- a/common.eai
+++ b/common.eai
@@ -495,6 +495,8 @@ globals
     integer racial_militiahero = 0
     integer racial_ghoul = 0
     integer racial_lumber = 0
+    integer racial_rushcreep = 0
+    unit rushcreep_target = null
     integer neutral_shredder = 0
     integer neutral_zeppelin = 0
     integer tp_item = 0
@@ -776,8 +778,8 @@ globals
     real array own_town_dist
     unit array own_town_mine
 
-    //location array exist_town
-    //integer exist_town_num = 0
+    location array exist_town
+    integer exist_town_num = 0
 
     integer attacking_ghouls = 0
     integer harvesting_ghouls = 0
@@ -4086,7 +4088,7 @@ endfunction
     // loop
 		// exitwhen (exitloop == true)
 		// //	call DisplayTextToPlayer(GetLocalPlayer(), 0, 0, "pathing loop")
-        // set l = Location(GetUnitX(u), GetUnitY(u))
+        // set l = GetUnitLoc(u)
         // set distance = DistanceBetweenPoints(l,target)
         // if distance <= buy_distance then
 		// //	call DisplayTextToPlayer(GetLocalPlayer(), 0, 0, "Tavern is pathable")
@@ -4584,7 +4586,7 @@ endfunction
 function GetUnitOfTypeNearUnit takes integer ut, unit nu returns unit
   local group g = CreateGroup()
   local unit u = null
-  local location unitloc = Location(GetUnitX(nu),GetUnitY(nu))
+  local location unitloc = GetUnitLoc(nu)
 
   call GroupEnumUnitsOfPlayer(g, ai_player, null)
   set g = SelectById(g, ut, true)
@@ -4602,7 +4604,7 @@ endfunction
 function GetUnusedZeppelinNearUnit takes unit nu returns unit
   local group g = CreateGroup()
   local unit u = null
-  local location unitloc = Location(GetUnitX(nu),GetUnitY(nu))
+  local location unitloc = GetUnitLoc(nu)
 
   call GroupEnumUnitsOfType(g, "goblinzeppelin", null)
   set g = SelectByPlayer(g, ai_player, true)
@@ -5546,7 +5548,7 @@ function BuildLumberMillAtBase takes nothing returns boolean
     endif
     set u = CreateUnitAtLoc(Player(PLAYER_NEUTRAL_PASSIVE), old_id[racial_lumber], buildloc, 270.0)
     call RemoveLocation(buildloc)
-    set buildloc = Location(GetUnitX(u),GetUnitY(u))
+    set buildloc = GetUnitLoc(u)
     call RemoveUnit(u)
     set u = null
     set b = IssuePointOrderByIdLoc(peon, old_id[racial_lumber], buildloc)
@@ -5559,6 +5561,111 @@ function BuildLumberMillAtBase takes nothing returns boolean
   endif
   return b
 endfunction
+
+//============================================================================
+// Gets the best location to build a RushCreep building , if use GetCreepCamp , then location cannot control
+//============================================================================
+function BuildBRAtCreep takes nothing returns nothing
+ local integer i = 0
+ local integer r = 0
+ local integer s = 0
+ local integer ru = 0
+ local real distance = 3200
+ local group g = CreateGroup()
+ local unit u = null
+ local unit array ua
+ local unit array ub
+ local unit array uc
+ local location loc = null
+ call GroupEnumUnitsInRange(g,GetLocationX(home_location), GetLocationY(home_location),distance,null)
+ set g = SelectByPlayer(g, Player(PLAYER_NEUTRAL_AGGRESSIVE), true)
+ set g = SelectUnittype(g, UNIT_TYPE_FLYING, false)
+ set g = SelectByAlive(g, true)
+ loop
+   set u = FirstOfGroup(g)
+   exitwhen u == null or i >= 7  //7 shoul have 2 creepcamp
+   if GetUnitLevel(u) < 5 and (uc[0] == null or (uc[0] != null and DistanceBetweenUnits(u, uc[0]) > 600) or (uc[1] != null and DistanceBetweenUnits(u, uc[1]) > 600)) then  //maybe have same camp creep unit not cleaned up
+     set ua[i] = CreatePathingUnit(ua[i])
+     call IssuePointOrder(ua[i], "move", GetUnitX(u), GetUnitY(u))
+     set ub[i] = CreatePathingUnitFull(ub[i],ai_player,groundid,GetUnitX(u), GetUnitY(u))
+     call IssueTargetOrder(ub[i], "smart", ua[i])  //go in opposite directions , save time
+     set uc[i] = u
+     set i = i + 1
+   endif
+   call GroupRemoveUnit(g,u)
+ endloop
+ call DestroyGroup(g)
+ set g = null
+ set u = null
+ if i == 0 then
+   return
+ endif
+ set ru = i
+ loop
+   if i == ru then
+     set i = 0
+   endif
+   exitwhen loc != null or s == ru
+   if (DistanceBetweenUnits(ua[i], ub[i]) < 200 or DistanceBetweenUnits(ua[i], uc[i]) < 600) and GetUnitState(uc[i], UNIT_STATE_LIFE) > 0 then
+     set loc = GetUnitLoc(uc[i])
+     set rushcreep_target = uc[i]
+   elseif GetUnitState(ua[i], UNIT_STATE_LIFE) <= 0 or GetUnitCurrentOrder(ua[i]) == OrderId("stop") or GetUnitCurrentOrder(ua[i]) != OrderId("move") or DistanceBetweenPoints_kd(home_location,GetUnitLoc(ua[i])) > 3200 then
+     set s = s + 1
+   elseif GetUnitState(ub[i], UNIT_STATE_LIFE) <= 0 or DistanceBetweenPoints_kd(home_location,GetUnitLoc(ub[i])) > 3200 then
+     set s = s + 1
+   elseif GetUnitState(uc[i], UNIT_STATE_LIFE) <= 0 then
+     set s = s + 1
+   endif
+   set i = i + 1
+   call Sleep(0.05)
+ endloop
+ set i = 0
+ loop
+   exitwhen i == ru
+   call RemoveUnit(ua[i])
+   set ua[i] = null
+   call RemoveUnit(ub[i])
+   set ub[i] = null
+   set uc[i] = null
+   set i = i + 1
+ endloop
+ if s == ru or loc == null then  // fail , not found creep
+   return
+ endif
+ set loc = GetBuildLocationInDistanceFromLoc_d(old_id[racial_rushcreep], loc, 600)
+ if loc != null and DistanceBetweenPoints(loc, home_location) < distance then  //Prevent some islands/shallow water terrain from creating u on the other side of the map
+   set g = CreateGroup()
+   call GroupEnumUnitsInRangeOfLoc(g, loc, 510, null)
+   loop
+     set u = FirstOfGroup(g)
+     exitwhen u == null or s == -2
+     if IsPlayerEnemy(GetOwningPlayer(u), ai_player) then  //if have enemy , cannot build (if use getlocationstrength need judge twice -- creep and player)
+       set s = -2
+     endif
+     call GroupRemoveUnit(g,u)
+   endloop
+   if s != -2 then
+     set u = GetExpansionPeon2()
+     if u == null or GetUnitCurrentOrder(u) != OrderId("harvest") then
+       call GroupClear(g)
+       call GroupEnumUnitsOfPlayer(g, ai_player, null)
+       set g = SelectUnittype(g, UNIT_TYPE_PEON, true)
+       set g = SelectByLoaded(g, true)
+       set u = FirstOfGroup(g)
+       call IssueTargetOrder(own_town_mine[0], "unload", u)
+       call Sleep(0.01)
+     endif
+     call RemoveGuardPosition(u)  // no need reset guard , the tree can train
+     call IssuePointOrderByIdLoc(u, old_id[racial_rushcreep], loc)
+   endif
+   call DestroyGroup(g)
+   set g = null
+   set u = null
+ endif
+ call RemoveLocation(loc)
+ set loc = null
+endfunction
+
 
 //============================================================================
 function CheckExpansionTaken takes unit expa returns boolean
@@ -6173,7 +6280,7 @@ function ChooseExpansion takes nothing returns nothing
     loop
       exitwhen i >= water_expansion_list_length
       if not CheckExpansionTaken(water_expansion_list[i]) then
-        call add_exp(water_expansion_list[i], 60, expansion_ancient[i], expansion_creeps[i])
+        call add_exp(water_expansion_list[i], 60, null, water_expansion_creeps[i])
       endif
       set i = i + 1
     endloop
@@ -6307,15 +6414,17 @@ endfunction
 
 //============================================================================
 function AddFrontPoint takes location l returns nothing
-  local unit pathable = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), groundid, GetLocationX(l), GetLocationY(l), 270.00)
+  local real x = GetLocationX(l)
+  local real y = GetLocationY(l)
+  local unit pathable = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), groundid, x, y, 270.00)
   if DistanceBetweenPoints_dk(GetUnitLoc(pathable), l) <= 200 then
-    call CreateDebugTagLoc("Front Point Added", 10, GetLocationX(l), GetLocationY(l), 60.00, 55.00)
-    set front_loc[front_loc_num] = Location(GetLocationX(l),GetLocationY(l))
+    call CreateDebugTagLoc("Front Point Added", 10, x, y, 60.00, 55.00)
+    set front_loc[front_loc_num] = l
     set front_loc_num = front_loc_num + 1
-  //else
-    //call CreateDebugTagLoc("Front Point : Not Buildable", 10, GetLocationX(l), GetLocationY(l), 60.00, 55.00)
+  else
+    //call CreateDebugTagLoc("Front Point : Not Buildable", 10, x, y, 60.00, 55.00)
+    call RemoveLocation(l)
   endif
-  call RemoveLocation(l)
   call RemoveUnit(pathable)
   set pathable = null
 endfunction
@@ -6352,7 +6461,7 @@ function ComputeFrontPoints takes nothing returns nothing
       exitwhen i >= n
       if patherdone[i] == false then
         if u[i] != null then
-          set l = Location(GetUnitX(u[i]),GetUnitY(u[i]))
+          set l = GetUnitLoc(u[i])
           set distance = DistanceBetweenPoints(l, home_location)
           if distance >= front_base_distance then
             call CreateDebugTag("Front Point Found", 10, u[i], 10.00, 8.00)
@@ -7487,12 +7596,11 @@ function InitTownBuilt takes nothing returns nothing
   loop
     exitwhen i >= max_towns
     set town_built[i] = false
-    //set exist_town[i] = home_location
     set i = i + 1
   endloop
   set town_built[0] = true
   set own_town_loc[0] = Location(GetLocationX(home_location), GetLocationY(home_location))
-  //set exist_town[0] = home_location
+  set exist_town[0] = home_location
   set own_town_dist[0] = 0
   set own_town_mine[0] = GetMineNearLoc(home_location, 1500)
 endfunction
@@ -9014,6 +9122,15 @@ function AddHarass takes integer groupnum, integer qty, integer unitid returns n
   set harass_size[groupnum] = harass_size[groupnum] + 1
 endfunction
 
+function RemoveHarass takes nothing returns nothing
+ local integer i = 0
+ loop
+   set harass_size[i] = 0
+   set i = i + 1
+   exitwhen i == 5
+ endloop
+endfunction
+
 function AddHarassUnittype takes integer groupnum, integer harassnum, group g, group harasser, integer key returns group
   local group cg = CopyGroup(g)
   local unit u = null
@@ -9084,15 +9201,20 @@ function StartHarass takes integer groupnum, integer harass_target, boolean avoi
 endfunction
 
 function GetHarassGroupStrength takes integer groupnum returns real
-  local integer i = 0
   local real sum = 0
+  local real p = GetPlayerHandicap(ai_player)
   local integer id = 0
+  local unit u = null
+  local group g = CopyGroup(unit_harassing)
   loop
-    exitwhen i >= harass_size[groupnum]
-    set id = harass_units[i*max_harass_groups + groupnum]
-    set sum = sum + Min(harass_qty[i*max_harass_groups + groupnum], TownCountDone(id)) * GetFoodUsed(old_id[id]) * GetPlayerHandicap(ai_player)
-    set i = i + 1
+    set u = FirstOfGroup(g)
+    exitwhen u == null
+    set id = GetUnitTypeId(u)
+    set sum = TownCountDone(id) * GetFoodUsed(id) * p
+   call GroupRemoveUnit(g, u)
   endloop
+  call DestroyGroup(g)
+  set g = null
   return sum
 endfunction
 
@@ -9100,6 +9222,7 @@ function Harass takes integer groupnum, integer harass_target, boolean avoid_tow
   if cond and ai_time - harass_time[groupnum] >= time and ai_time >= min_time then
     call StartHarass(groupnum, harass_target, avoid_towers, strength_limit, flee_percent, flee_number, 0, 0)
   endif
+  call RemoveHarass()
 endfunction
 
 //============================================================================
@@ -9653,6 +9776,14 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
       return GetNeutralHero(unitid)
     endif
 
+   if unitid == racial_rushcreep then
+     if CreepsOnMap() and not towerrush then
+       call BuildBRAtCreep()
+     endif
+     set racial_rushcreep = -1  //just run once
+     return BUILT_SOME
+   endif
+
     if buy_type[unitid] > BT_RACIAL_ITEM and buy_type[unitid] <= BT_MERCHANT_ITEM then
       if not (neutral_ordered[nn] or attack_running) and nearest_neutral[nn] != null then
         set neutral_ordered[nn] = true
@@ -9714,7 +9845,7 @@ function ConstructExpansion takes unit peon, integer unitid returns boolean
       return false
     endif
     call RemoveLocation(exp_loc_cache)
-    set exp_loc_cache = Location(GetUnitX(u), GetUnitY(u))
+    set exp_loc_cache = GetUnitLoc(u)
     set exp_loc_cache_timeout = ai_time + 4
   //  call SetUnitExploded(u, true)
   //  call KillUnit(u)
@@ -10237,7 +10368,7 @@ function InitHeroInfo takes integer hn returns nothing
   if hero_loc[hn] != null then
     call RemoveLocation(hero_loc[hn])
   endif
-  set hero_loc[hn] = Location(GetUnitX(hero_unit[hn]), GetUnitY(hero_unit[hn]))
+  set hero_loc[hn] = GetUnitLoc(hero_unit[hn])
   if hero_enemy_loc[hn] != null then
     call RemoveLocation(hero_enemy_loc[hn])
   endif
@@ -10288,6 +10419,32 @@ function CheckUnitNewTown takes unit u, integer num returns boolean
 endfunction
 
 //============================================================================
+function LocalizeOldTown takes integer num returns boolean
+  local group g = CreateGroup()
+  local unit u = null
+  call GroupEnumUnitsInRangeOfLoc(g, own_town_loc[num], 2000, null)
+  set g = SelectByPlayer(g,ai_player,true)
+  set g = SelectByHidden(g,false)
+  set g = SelectByAlive(g,true)
+  loop
+    set u = FirstOfGroup(g)
+    exitwhen u == null
+    exitwhen IsUnitType(u, UNIT_TYPE_STRUCTURE)
+    call GroupRemoveUnit(g,u)
+  endloop
+  call DestroyGroup(g)
+  set g = null
+  if u == null then
+    if num != 0 then  //Prevent moving away from the starting loc
+      set exist_town[exist_town_num] = home_location
+    endif
+    return false
+  endif
+  set exist_town_num = exist_town_num + 1
+  set u = null
+  return true
+endfunction
+
 function LocalizeNewTown takes integer num returns boolean
   local group g = CreateGroup()
   local unit u = null
@@ -10303,7 +10460,9 @@ function LocalizeNewTown takes integer num returns boolean
   endloop
   call DestroyGroup(g)
   set g = null
-  call RemoveLocation(own_town_loc[num])
+  if own_town_loc[num] != null then
+    call RemoveLocation(own_town_loc[num])
+  endif
   if u == null then
 //    call DisplayToAll("Debug: New town not found")
     set own_town_loc[num] = null
@@ -10311,9 +10470,11 @@ function LocalizeNewTown takes integer num returns boolean
     set own_town_dist[num] = 0
     return false
   endif
-  set own_town_loc[num] = Location(GetUnitX(u),GetUnitY(u))
+  set own_town_loc[num] = GetUnitLoc(u)
   set own_town_mine[num] = GetMineNearLoc(own_town_loc[num], 1500)
   set own_town_dist[num] = DistanceBetweenPoints(home_location, own_town_loc[num])
+  set exist_town[exist_town_num] = own_town_loc[num]
+  set exist_town_num = exist_town_num + 1
   if debugging then
     call PingMinimap(GetUnitX(u), GetUnitY(u), 20)
   endif
@@ -10324,23 +10485,16 @@ endfunction
 //============================================================================
 function CheckTownBuilt takes nothing returns nothing
   local integer i = 0
-  //set exist_town_num = 0  //reserve
-  // Replace p with sent home job using exist_town[i]
-  // It is possible to transport injured units back to different towns
-  // To avoid being completely killed by the enemy at once on home
-  // Just fix the percentage of sent home job health points
-  // Submit it next time(Maybe)
+  set exist_town_num = 0
   loop
     exitwhen i >= max_towns
     if not town_built[i] then
       if (TownCountEx(racial_expansion, true, i) > 0 and not (TownCountEx(racial_expansion, true, 50) > 0)) then
         set town_built[i] = LocalizeNewTown(i)
       endif
+    else
+       set town_built[i] = LocalizeOldTown(i)
     endif
-    // if own_town_loc[i] != null and exist_town[exist_town_num] != own_town_loc[i] then  // prevent town from being dismantled completely
-    //   set exist_town[exist_town_num] = own_town_loc[i]
-    //   set exist_town_num = exist_town_num + 1
-    // endif
     set i = i + 1
   endloop
 endfunction
@@ -10594,6 +10748,35 @@ function AttackGroupAddNeutrals takes nothing returns nothing
   endloop
 endfunction
 
+function AttackGroupAddUnknown takes nothing returns nothing
+  local group g = CreateGroup()
+  local unit u = null
+  local integer id = 0
+  local integer i = 0
+  call GroupEnumUnitsOfPlayer(g, ai_player, null)
+  set g = SelectUnittype(g, UNIT_TYPE_PEON, false)
+  set g = SelectUnittype(g, UNIT_TYPE_STRUCTURE, false)
+  set g = SelectUnittype(g, UNIT_TYPE_SUMMONED, false)
+  set g = SelectByHidden(g,false)
+  set g = SelectByAlive(g,true)
+  loop
+    exitwhen i >= attack_length or FirstOfGroup(g) == null
+    set g = SelectById(g, old_id[attack_units[i]], false)
+    set i = i + 1
+  endloop
+  loop
+    set u = FirstOfGroup(g)
+    exitwhen u == null
+    set id = GetUnitTypeId(u)
+    if (IsUnitType(u, UNIT_TYPE_ATTACKS_FLYING) or IsUnitType(u, UNIT_TYPE_ATTACKS_GROUND)) and id != 'ngir' then
+      call AddAssault(60,id)  //other hero and unit , like other race and custom
+    endif
+    call GroupRemoveUnit(g, u)
+  endloop
+  call DestroyGroup(g)
+  set g = null
+endfunction
+
 //============================================================================
 function FormGroupAM takes integer seconds returns nothing
   local integer index = 0
@@ -10683,6 +10866,7 @@ function DoDistractionAttack takes unit target returns nothing
   endif
   call StartHarass(distraction_group, HARASS_TARGET_LOCATION, false, 15, 0.25, 1, GetUnitX(d_target), GetUnitY(d_target))
   set d_target = null
+  call RemoveHarass()
   call Sleep(15)
 endfunction
 
@@ -10726,7 +10910,7 @@ endfunction
 function GetNearAlliedStrength takes unit target returns real
   local integer i = 0
   local real sum = 0
-  local location unitloc = Location(GetUnitX(target),GetUnitY(target))
+  local location unitloc = GetUnitLoc(target)
   local real dist = DistanceBetweenPoints(unitloc, ally_loc) + 600
   loop
     exitwhen i >= army_num
@@ -10909,6 +11093,62 @@ function SleepUntilAtGoalAM takes nothing returns nothing
     //call Trace("Sleeping until target reached")
     call Sleep(2 * sleep_multiplier)
   endloop
+endfunction
+
+//============================================================================
+function BRRush takes nothing returns nothing
+  local location buildloc = null
+  local location loc = null
+  local unit u = null
+  local unit utemp = null
+  local group g = CreateGroup()
+  local integer i = 0
+  call GroupEnumUnitsInRange(g,GetUnitX(rushcreep_target), GetUnitY(rushcreep_target),800,null)
+  loop
+    set u = FirstOfGroup(g)
+    exitwhen u == null or i == 1
+    if UnitAlive(u) and GetOwningPlayer(u) != Player(PLAYER_NEUTRAL_AGGRESSIVE) and IsPlayerEnemy(ai_player,GetOwningPlayer(u)) then
+      set i = 1  // have other player
+    elseif GetOwningPlayer(u) == ai_player and GetUnitTypeId(u) == 'eaom' then
+      set utemp = u
+    endif
+    call GroupRemoveUnit(g, u)
+  endloop
+  call DestroyGroup(g)
+  set g = null
+  set attack_running = true
+  if i != 1 and GetUnitState(utemp, UNIT_STATE_LIFE) >= GetUnitState(utemp, UNIT_STATE_MAX_LIFE) * 0.65 then
+    set buildloc = GetUnitLoc(utemp)
+    call RemoveGuardPosition(utemp)
+    call IssueImmediateOrder(utemp, "unroot")  //try unroot
+    call Sleep(2.8)  //unroot time
+    set loc = GetUnitLoc(rushcreep_target)
+    call IssuePointOrderLoc(utemp, "attack", loc)
+    call RemoveLocation(loc)
+    set loc = null
+    call AttackMoveKill(rushcreep_target)
+    call ReformUntilTargetDeadAM(rushcreep_target, true)
+    call Chat(C_Done)
+    call SleepInCombatAM()
+    call Trace("===BR Finished===")
+    call IssuePointOrderLoc( utemp, "move", buildloc)  //prevent inability cannot root
+    call Sleep(0.02)
+    call IssuePointOrderLoc( utemp, "root", buildloc)  //root tree
+    call TQAddUnitJob(GetTimeToReachLoc(utemp, buildloc) + 2, RESET_GUARD_POSITION, 0, u)
+    call RemoveLocation(buildloc)
+    set buildloc = null
+  else
+    call AttackMoveKill(rushcreep_target)
+    call ReformUntilTargetDeadAM(rushcreep_target, true)
+    call Chat(C_Done)
+    call SleepInCombatAM()
+    call Trace("===BR Finished , no tree ===")
+  endif
+  set attack_running = false
+  if not UnitAlive(rushcreep_target) then
+    set rushcreep_target = null
+  endif
+  set utemp = null
 endfunction
 
 //============================================================================
@@ -11548,12 +11788,10 @@ function SleepUntilTownDefended takes integer ai_strength returns nothing
 	loop
 		exitwhen not town_threatened
 		exitwhen player_defeated
-		if town_loc[most_threatened_town] != null then
-			if LinearInterpolation(ver_low_aggression,ver_high_aggression,ver_flee_multiple1,ver_flee_multiple2,attacking_aggression)*own_strength > army_strength[town_threat_army[most_threatened_town]] then
-				if town_threat[most_threatened_town] >= teleport_low_threat then
-					if not teleporting then
-						call AttackMoveXY(R2I(GetLocationX(town_loc[most_threatened_town])), R2I(GetLocationY(town_loc[most_threatened_town])))
-					endif
+		if town_loc[most_threatened_town] != null and LinearInterpolation(ver_low_aggression,ver_high_aggression,ver_flee_multiple1,ver_flee_multiple2,attacking_aggression)*own_strength > army_strength[town_threat_army[most_threatened_town]] then
+			if town_threat[most_threatened_town] >= teleport_low_threat then
+				if not teleporting then
+					call AttackMoveXY(R2I(GetLocationX(town_loc[most_threatened_town])), R2I(GetLocationY(town_loc[most_threatened_town])))
 				endif
 			endif
 			call SetCaptainHome(DEFENSE_CAPTAIN, GetLocationX(town_loc[most_threatened_town]), GetLocationY(town_loc[most_threatened_town]))
@@ -11586,7 +11824,7 @@ function SetLeadAlly takes nothing returns nothing
   local player p = null
   loop
     exitwhen i >= force_number or checkdone
-    set p = ally_force[i]
+    set p = own_force[i]
     if GetPlayerSlotState(p) == PLAYER_SLOT_STATE_PLAYING then
       if p != ai_player then
         set leadally = false
@@ -11602,7 +11840,7 @@ endfunction
 //============================================================================
 // AMAI SingleMeleeAttack
 //============================================================================
-function SingleMeleeAttackAM takes boolean needs_exp, boolean has_siege, integer ai_strength returns nothing
+function SingleMeleeAttackAM takes boolean needs_exp, boolean has_siege, boolean br_rush, integer ai_strength returns nothing
   local unit hall = null
   local unit mega = null
   local unit creep = null
@@ -11797,6 +12035,16 @@ function SingleMeleeAttackAM takes boolean needs_exp, boolean has_siege, integer
       endif
       return
     endif
+
+    // ELF BR
+    //
+    if br_rush and rushcreep_target != null and UnitAlive(rushcreep_target) then
+      call Trace("ELF BR Attack")
+      call FormGroupAM(3)
+      call BRRush()  //try BR
+      return
+    endif
+
 
     // defend expansion from other expansion
     //
@@ -12119,7 +12367,7 @@ function ApplyHealingItem takes unit u, item heal_item returns nothing
 	local group medium = null
 
 	set urgent = CopyGroup(urgent_healing_group)
-	set medium = CopyGroup(medium_healing_group)	
+	set medium = CopyGroup(medium_healing_group)
 	call RemoveGuardPosition(u)
 	call GroupPointOrder(urgent_healing_group, "move", GetUnitX(u), GetUnitY(u))
 	call GroupPointOrder(medium_healing_group, "move", GetUnitX(u), GetUnitY(u))
@@ -12240,6 +12488,7 @@ endfunction
 function universal_attack_sequence takes nothing returns nothing
   local boolean needs_exp = false
   local boolean has_siege = false
+  local boolean br_rush = false
   local integer ai_strength = 0
   //local integer ai_antiair_strength = 0
   local integer exp_strength = 0
@@ -12248,10 +12497,14 @@ function universal_attack_sequence takes nothing returns nothing
     call Sleep(sleep_multiplier)
     return
   endif
+  call SetTargetHeroes(difficulty != EASY)
   set ai_strength = GetOwnStrength()
   //set ai_antiair_strength = air_strength
   if current_expansion != null then
     set exp_strength = GetExpansionStrength()
+  endif
+  if rushcreep_target != null and UnitAlive(rushcreep_target) then
+    set br_rush = GetLocationCreepStrength(GetUnitX(rushcreep_target), GetUnitY(rushcreep_target), 510) <= ai_strength * 0.7
   endif
   set most_threatened_town = Max(most_threatened_town,0)
   if major_hero == null or not UnitAlive(major_hero) or not IsStandardUnit(major_hero) or (IsUnitType(major_hero, UNIT_TYPE_HERO) == false and ver_heroes) then
@@ -12264,7 +12517,7 @@ function universal_attack_sequence takes nothing returns nothing
   set has_siege        = has_siege or TownCountDone(%1) > 0
 #ENDINCLUDE
 
-  call SingleMeleeAttackAM(needs_exp,has_siege,ai_strength)
+  call SingleMeleeAttackAM(needs_exp,has_siege,br_rush,ai_strength)
   set added_target_aggression = 0
   set added_racial_aggression = 0
 
@@ -12882,7 +13135,7 @@ endfunction
 function StartExpansion takes integer qty, integer hall returns boolean
     local integer count
     local integer town
-    local unit    peon
+    local unit    peon = null
     local integer gold_cost
     local boolean b = true
 
@@ -13637,7 +13890,7 @@ endfunction
 
 //============================================================================
 function AnyPlayerAttack takes nothing returns nothing
-  local unit hall= GetEnemyExpansion()
+  local unit hall = GetEnemyExpansion()
 
   if hall == null then
     call StartGetEnemyBase()

--- a/common.eai
+++ b/common.eai
@@ -12504,7 +12504,7 @@ function universal_attack_sequence takes nothing returns nothing
     set exp_strength = GetExpansionStrength()
   endif
   if rushcreep_target != null and UnitAlive(rushcreep_target) then
-    set br_rush = GetLocationCreepStrength(GetUnitX(rushcreep_target), GetUnitY(rushcreep_target), 510) <= ai_strength * 0.7
+    set br_rush = GetLocationCreepStrength(GetUnitX(rushcreep_target), GetUnitY(rushcreep_target), 510) <= ai_strength * 0.6
   endif
   set most_threatened_town = Max(most_threatened_town,0)
   if major_hero == null or not UnitAlive(major_hero) or not IsStandardUnit(major_hero) or (IsUnitType(major_hero, UNIT_TYPE_HERO) == false and ver_heroes) then

--- a/races.eai
+++ b/races.eai
@@ -498,6 +498,7 @@ function setup_force takes boolean inj returns nothing
 #ENDINCLUDE
     
     call AttackGroupAddNeutrals()
+    call AttackGroupAddUnknown()
 
 endfunction
 


### PR DESCRIPTION
**ADD**
- ELF BR build and BR attack,  https://github.com/SMUnlimited/AMAI/issues/85
  -- (DevTools)  set type to rushcreep on StandardUnits.txt  , but now unroot and root cannot Dev , this is hard-coding , if set unit non tree , then cannot unroot and attack
  -- Occasionally , it may not be possible root
  --  only non EASY can build , because EASY only build one barracks , no redundancy, the risk is too high
- RemoveHarass , try fix https://github.com/SMUnlimited/AMAI/issues/169
  -- GetHarassGroupStrength take unit_harassing group  's unit Strength (Please pay special attention, I don't know if this will break the logic)
- LocalizeOldTown , check old town , preventing the destruction of the base(use to send home)
- AttackGroupAddUnknown , AI can take unkown unit , like not own race unit or custom map unit（Inefficient）


**CHANGE**
- now save unit , AI will randomly send units to different bases to avoid being together killed by the enemy  - use exist_town
  -- zeppelin can go to different bases , too
  -- now TQAddUnitJob(2, SEND_HOME, 0, u) cannot transfer Health Percentage , only transfer Base number , 0 is home_location
- send home job use item order  only control hero
- save unit now can save phoenix and racial militia
- save unit single judgment healer ,  if healer non group therapy , units will still be pulled away during , this can fix the wander low health units during the battle
- ZeppelinMove JOB  immediately release Zeppelin control when move fail or complete
- Fountain job support active use AIhm , https://github.com/SMUnlimited/AMAI/issues/167
  -- have some JOB just control unit , no control hero , so I do not add AIhm , to maintain its original functionality 
- windwalk order judgment Ability level （there are still some areas that have not been modified, like FOCUSFIRE_CONTROL）
- Russian UP (Lolasik011)  https://github.com/jzy-chitong56/AMAI/pull/25
- (DevTools) Optimize.bat change imitate MakeAll.bat
- (DevTools) Optimize.bat and MakeAll.bat final compilation TFT, prevent BJ final generation ROC
- (DevTools) MakeOptROC.bat code synchronization to MakeOptTFT.bat


**FIX**
- fix take unit loc now use unitloc()
- fix ChooseExpansion add water_expansion_list use expansion_creeps and no need expansion_ancient
- fix some ally player judgment error
- fix SetTargetHeroes not restored after setting （there are still some areas that have not been modified, like FOCUSFIRE_CONTROL）
- fix saveyourself no open ancient_exp_nobuild but repeated DETECT_DEFEAT JOB run once
- fix InitZoom
- fix CreatePathingUnitFull only create own unit


**Code optimization and Excrete**

-------------------------------------------------------------------------------
InitZoom
```
call TriggerAddAction(AdjustZoomUp , function ZoomUp)
call TriggerAddAction(AdjustZoomDown , function ZoomDown)
```
Unable to function properly now ，maybe you need check and fix
and Observer zoom seems unadjusted

-------------------------------------------------------------------------------
**Ask a question**
There is now a code for registering  Deny unit
I don't know where to execute better , so this pull no kill Deny unit
It takes effect immediately in Saveunit , it is more logical should in FOCUSFIRE_CONTROL(but maybe cannot Deny)

That's right, hope you can add w3c Deny tip to Blizzard

-------------------------------------------------------------------------------
There are not many new features left, most of which are adjustments and optimizations
Maybe you need to double check if I broke the logic
