### PR TITLE
some excrete

### DIFF
--- a/Jobs/FAST_BUILD.eai
+++ b/Jobs/FAST_BUILD.eai
@@ -14,67 +14,70 @@
 function GetFastBuildPeasantNumber takes nothing returns integer
   local integer minres = Min(GetGold(),GetWood())
   if minres < 40 or GetMinesOwned() == 0 then
-	//call Trace("0 fast build peasants")
+    //call Trace("0 fast build peasants")
     return 0
   elseif minres < 250 then  
-  	//call Trace("1 fast build peasant")
+    //call Trace("1 fast build peasant")
     return 1
   elseif minres < 350 then
-  	//call Trace("2 fast build peasants")
+    //call Trace("2 fast build peasants")
     return 2
   elseif minres < 450 then
-  	//call Trace("3 fast build peasants")
+    //call Trace("3 fast build peasants")
     return 3
   else
-  	//call Trace("4 fast build peasants")
+    //call Trace("4 fast build peasants")
     return 4
   endif
 endfunction
 
-function GetBuildingBuilt takes nothing returns unit
-     local group g = CreateGroup()
-	 if expansion_changed then
-		call GroupEnumUnitsInRange(g, last_expansion_x, last_expansion_y, 1000, null)
-     else
-		call GroupEnumUnitsInRange(g, next_expansion_x, next_expansion_y, 1000, null)	 
-	 endif
-	 set g = SelectByPlayer(g, ai_player, true)
-     set g = SelectNumberOfId(g, 1, old_id[racial_hall[1]])
-     return FirstOfGroup(g)
+function GetBuildingBuilt takes unit u returns unit
+  local group g = CreateGroup()
+  if expansion_changed then
+    call GroupEnumUnitsInRange(g, last_expansion_x, last_expansion_y, 1000, null)
+  else
+    call GroupEnumUnitsInRange(g, next_expansion_x, next_expansion_y, 1000, null)	 
+  endif
+  set g = SelectByPlayer(g, ai_player, true)
+  set g = SelectNumberOfId(g, 1, old_id[racial_hall[1]])
+  set u = FirstOfGroup(g)
+  call DestroyGroup(g)
+  set g = null
+  return u
 endfunction
 
 function FastBuildBuilding takes nothing returns nothing
-  local unit u = GetBuildingBuilt()
-  local group tempg = CreateGroup()
+  local unit u = null
   local group g = null
-  local location unitloc = GetUnitLoc(u)
-  
+  local location unitloc = null
+  set u = GetBuildingBuilt(u)
   call Trace("Town hall is being built soon")
   if u == null then
     return
   endif
+  set unitloc = GetUnitLoc(u)
+  set g = CreateGroup()
   call Trace("Town hall is being built")
-	 call GroupEnumUnitsOfPlayer(tempg, ai_player,null)
-	 set tempg = SelectNumberOfId(tempg, 50, old_id[racial_militia] )
-	 set tempg = SelectByAlive(tempg, true)
-	 if FirstOfGroup(tempg) == null then
-		call DestroyGroup(tempg)
-		set tempg = CreateGroup()
-		call GroupEnumUnitsOfPlayer(tempg, ai_player, null)	 
-		set tempg = SelectNumberOfId(tempg, 50, old_id[racial_peon] )
-		set tempg = SelectByAlive(tempg, true)
-	 endif
-  call GroupClear(g)  
-  set g = GetNearestSubGroupOfGroup(tempg, unitloc, GetFastBuildPeasantNumber())
+  call GroupEnumUnitsOfPlayer(g, ai_player,null)
+  set g = SelectNumberOfId(g, 50, old_id[racial_militia] )
+  set g = SelectByHidden(g, false)
+  set g = SelectByAlive(g, true)
+  if FirstOfGroup(g) == null then
+    call GroupClear(g)
+    call GroupEnumUnitsOfPlayer(g, ai_player, null)
+    set g = SelectNumberOfId(g, 50, old_id[racial_peon] )
+    set g = SelectByHidden(g, false)
+    set g = SelectByAlive(g, true)
+  endif
+  set g = GetNearestSubGroupOfGroup(g, unitloc, GetFastBuildPeasantNumber())
   call GroupTargetOrder(g, "repair", u)
   call Trace("Fast Build Town Hall")
   set town_hall_built = true
   call RemoveLocation(unitloc)
-  call DestroyGroup(tempg)
   call DestroyGroup(g)
   set unitloc = null
-  set tempg = null
   set g = null
+  set u = null
 endfunction
 
 function FastBuildCheck takes nothing returns nothing
@@ -90,7 +93,7 @@ function FastBuildCheck takes nothing returns nothing
   if TownCount(racial_hall[1]) - TownCountDone(racial_hall[1]) > 0 then
     //if expansion_changed and not town_hall_built then
     if not town_hall_built then  
-	  call FastBuildBuilding()
+      call FastBuildBuilding()
     endif
   else
     set town_hall_built = false
@@ -98,7 +101,9 @@ function FastBuildCheck takes nothing returns nothing
 endfunction
 
 function FastBuild takes nothing returns nothing
-	call FastBuildCheck()
-	call TQAddJob(10, FAST_BUILD, 0)
+  if current_expansion != null and not towerrush then
+    call FastBuildCheck()
+  endif
+  call TQAddJob(10, FAST_BUILD, 0)
 endfunction
 #ENDIF

--- a/Jobs/MILITIA_EXPAND.eai
+++ b/Jobs/MILITIA_EXPAND.eai
@@ -14,86 +14,79 @@ location militia_loc = null
 
 #ELSE
 
-function GetMilitiaExpansionLoc takes integer unitid returns location
-	local unit u = null
-	local location l = null
-
-	set u = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), unitid, GetUnitX(militia_expansion), GetUnitY(militia_expansion), 270.0)
+function GetMilitiaExpansionLoc takes integer unitid returns nothing
+    local unit u = CreateUnit(Player(PLAYER_NEUTRAL_PASSIVE), unitid, GetUnitX(militia_expansion), GetUnitY(militia_expansion), 270.0)
     if DistanceBetweenUnits(u, militia_expansion) > race_max_expa_mine_distance then
       call RemoveUnit(u)
       set u = null
-      return null
+      return
     endif	
-	set l = GetUnitLoc(u)
-	call RemoveUnit(u)
-	set u = null
-	return l
-	
+    set militia_loc = GetUnitLoc(u)
+    call RemoveUnit(u)
+    set u = null
+
 endfunction
 
 function BuildMilitiaExpansion takes unit peon , integer unitid returns boolean
-  local unit u = null
+  //local unit u = null
 
-    call Trace("did a check")
+  call Trace("did a check")
 
-	if militia_loc == null then
-		return false
-	endif
-	
-  if IssuePointOrderByIdLoc(peon, unitid, militia_loc) then
-	return true
-  else
-	return false
+  if militia_loc == null then
+    return false
   endif
-  
+
+  return IssuePointOrderByIdLoc(peon, unitid, militia_loc)
+
 endfunction
 
 function GetMilitiaExpansionStrength takes nothing returns integer
-	return GetLocationCreepStrength(GetUnitX(militia_expansion), GetUnitY(militia_expansion), expansion_radius)
+  return GetLocationCreepStrength(GetUnitX(militia_expansion), GetUnitY(militia_expansion), expansion_radius)
 endfunction
 
 function TryMilitiaExpansionFoot takes nothing returns nothing
 local group g = null
-local group tempg = null
-local integer ownstrength = GetOwnStrength()
+local integer ownstrength = 0
 local integer expansionstrength = 0
+local location l = null
 
+	call DisplayToAllJobDebug("MILITIA_EXPAND JOB START")
 
-  call DisplayToAllJobDebug("MILITIA_EXPAND JOB START")
-  
-  
+	if towerrush then
+		call TQAddJob(80, MILITIA_EXPAND, 0)
+		return
+	endif
+	set ownstrength = GetOwnStrength()
 	if militia_state == 0 then
-		if not militia_expanding and not towerrush then
-			if current_expansion != null then
-		      set militia_time_count = militia_time_count + 1
-			  call Trace("Expansion Distance: " + Int2Str(R2I(GetExpansionDistance())))
-		      //if GetExpansionDistance() <= 6600 and GetExpansionStrength() < 20 then //and militia_time_count < militia_time_out then //and GetExpansionStrength() < 36 then // and hero[1] == racial_militiahero then
-		      if GetExpansionDistance() <= 5800 and GetExpansionStrength() < 20 then
-		        if TownCount(hero[1]) > 0 then
-		        endif
-				set expansionstrength = GetExpansionStrength()
-				call Trace("Our Strength:" + Int2Str(ownstrength) + " Expansion Strength:" + Int2Str(expansionstrength))
-		        if TownCountDone(hero[1])>0 and not town_threatened and GetPlayerStrength(ai_player) >= minimum_attack_strength and TownCountDone(racial_peon) > 6 and ownstrength + 6 >= expansionstrength then
-		    		set gold_buffer = GetUnitGoldCost2(racial_expansion)
-					set wood_buffer = GetUnitWoodCost2(racial_expansion)	
-					set militia_expansion = current_expansion 
-					if GetGold() >= GetUnitGoldCost2(racial_expansion) and GetWood() >= GetUnitWoodCost2(racial_expansion) then
-					if GetMilitiaExpansionStrength() <= 0 then
-						set militia_expanding = false
-						set militia_state = 2
-					else
-						set militia_expanding = true
-						call Trace("Militia active")
-						set militia_state = 1
-					endif		
+	if not militia_expanding then
+		if current_expansion != null then
+		set militia_time_count = militia_time_count + 1
+		call Trace("Expansion Distance: " + Int2Str(R2I(GetExpansionDistance())))
+		set expansionstrength = GetExpansionStrength()
+		//if GetExpansionDistance() <= 6600 and expansionstrength < 20 then //and militia_time_count < militia_time_out then //and expansionstrength < 36 then // and hero[1] == racial_militiahero then
+		if GetExpansionDistance() <= 5800 and expansionstrength < 20 then
+			call Trace("Our Strength:" + Int2Str(ownstrength) + " Expansion Strength:" + Int2Str(expansionstrength))
+			if TownCountDone(hero[1])>0 and not town_threatened and GetPlayerStrength(ai_player) >= minimum_attack_strength and TownCountDone(racial_peon) > 6 and ownstrength + 6 >= expansionstrength then
+				set gold_buffer = GetUnitGoldCost2(racial_expansion)
+				set wood_buffer = GetUnitWoodCost2(racial_expansion)	
+				set militia_expansion = current_expansion 
+						if GetGold() >= GetUnitGoldCost2(racial_expansion) and GetWood() >= GetUnitWoodCost2(racial_expansion) then
+						if GetMilitiaExpansionStrength() <= 0 then
+							set militia_expanding = false
+							set militia_state = 2
+						else
+							set militia_expanding = true
+							call Trace("Militia active")
+							set militia_state = 1
+						endif		
+						endif
 					endif
-		        endif
-		      else
-		        set gold_buffer = 0
-		        set wood_buffer = 0
-		        call Trace("MILITIA_EXPAND: Militia expansion will not be done")
-		        set militia = false
-		      endif
+				else
+					set gold_buffer = 0
+					set wood_buffer = 0
+					call Trace("MILITIA_EXPAND: Militia expansion will not be done")
+					set militia = false
+				endif
 			endif
 		endif
 		if militia then
@@ -114,47 +107,49 @@ local integer expansionstrength = 0
 		endif
 		if militia then
 			call TQAddJob(2, MILITIA_EXPAND, 0)
-		endif	
+		endif
 	elseif militia_state == 2 then
-	 call Trace("Militia state 2")
-	 if GetMilitiaExpansionStrength() > 0 then
+	call Trace("Militia state 2")
+	if GetMilitiaExpansionStrength() > 0 then
 		set militia_state = 1
 		set militia_expanding = true
-	 endif
-	 set gold_buffer = GetUnitGoldCost2(racial_expansion)
-	 set wood_buffer = GetUnitWoodCost2(racial_expansion)	
-	 set g = CreateGroup()
-	 set tempg = CreateGroup()
-	 call GroupEnumUnitsOfPlayer(tempg, ai_player,null)
-	 set tempg = SelectNumberOfId(tempg, 50, old_id[racial_militia] )
-	 set tempg = SelectByAlive(tempg, true)
-	 if FirstOfGroup(tempg) == null then
+	endif
+	set gold_buffer = GetUnitGoldCost2(racial_expansion)
+	set wood_buffer = GetUnitWoodCost2(racial_expansion)	
+	set g = CreateGroup()
+	call GroupEnumUnitsOfPlayer(g, ai_player,null)
+	set g = SelectNumberOfId(g, 50, old_id[racial_militia] )
+	set g = SelectByHidden(g, false)
+	set g = SelectByAlive(g, true)
+	if FirstOfGroup(g) == null then
+		call GroupClear(g)
 		call GroupEnumUnitsOfPlayer(g, ai_player, null)	 
 		set g = SelectNumberOfId(g, 50, old_id[racial_peon] )
-		set tempg = GroupAddGroup(tempg, g)
-		set tempg = SelectByAlive(tempg, true)
-	 endif
-	 //call GroupClear(g)
-     set g = GetNearestSubGroupOfGroup(tempg, GetUnitLoc(current_expansion), 3)
-     set militia_builder =FirstOfGroup(g)
-	 call GroupRemoveUnit(g, militia_builder)
-	 set militia_fastb1 = FirstOfGroup(g)
-	 call GroupRemoveUnit(g, militia_fastb1)
-	 set militia_fastb2 = FirstOfGroup(g)
-	 call GroupRemoveUnit(g, militia_fastb2)
-	 set militia_fastb3 = FirstOfGroup(g)
-	 call RemoveGuardPosition(militia_builder)
-	 call DestroyGroup(tempg)
-	 call DestroyGroup(g)
-	 set tempg = null
-	 set g = null
-	 if militia_builder != null then
+		set g = SelectByHidden(g, false)
+		set g = SelectByAlive(g, true)
+	endif
+	//call GroupClear(g)
+	set l = GetUnitLoc(current_expansion)
+	set g = GetNearestSubGroupOfGroup(g, l, 4)
+	call RemoveLocation(l)
+	set l = null
+	set militia_builder = FirstOfGroup(g)
+	//call GroupRemoveUnit(g, militia_builder)
+	//set militia_fastb1 = FirstOfGroup(g)
+	//call GroupRemoveUnit(g, militia_fastb1)
+	//set militia_fastb2 = FirstOfGroup(g)
+	//call GroupRemoveUnit(g, militia_fastb2)
+	//set militia_fastb3 = FirstOfGroup(g)
+	call RemoveGuardPosition(militia_builder)
+	call DestroyGroup(g)
+	set g = null
+	if militia_builder != null then
 		set militia_state = 3
 		call Trace("Militia state 2 done")
 	 endif
 	 if militia then
 		call TQAddJob(2, MILITIA_EXPAND, 0)
-	 endif
+	endif
 	elseif militia_state == 3 then
 		if GetMilitiaExpansionStrength() > 0 then
 			set militia_state = 1
@@ -176,21 +171,21 @@ local integer expansionstrength = 0
 				return
 			endif
 			if militia_loc == null then
-				set militia_loc = GetMilitiaExpansionLoc(old_id[racial_expansion])
+				call GetMilitiaExpansionLoc(old_id[racial_expansion])
 			endif
 			if GetGold() >= GetUnitGoldCost2(racial_hall[1]) and GetWood() >= GetUnitWoodCost2(racial_hall[1]) then
 				//call IssueTargetOrder(militia_fastb1, "stop", current_expansion)
 				//call IssueTargetOrder(militia_fastb2, "stop", current_expansion)
 				call RecycleGuardPosition(militia_builder)  // has to be here or peasant comes off construction
-				call BuildMilitiaExpansion(militia_builder, old_id[racial_expansion])		
+				call BuildMilitiaExpansion(militia_builder, old_id[racial_expansion])
 				//set militia = false
 				//set militia_state = 0
 				//set militia_expansion = null
-				call Trace("Militia Build commanded")			
+				call Trace("Militia Build commanded")
 			else 
 				set gold_buffer = GetUnitGoldCost2(racial_expansion)
-				set wood_buffer = GetUnitWoodCost2(racial_expansion)	
-			    call Trace("Moving near")
+				set wood_buffer = GetUnitWoodCost2(racial_expansion)
+				call Trace("Moving near")
 				call RemoveGuardPosition(militia_builder)
 				if militia_loc == null then
 					call IssueTargetOrder(militia_builder, "move", current_expansion)

--- a/Jobs/TOWER_RUSH.eai
+++ b/Jobs/TOWER_RUSH.eai
@@ -181,7 +181,7 @@ endif
 	call GroupEnumUnitsOfPlayer(g, ai_player, null)
 	set g = SelectByAlive(g,true)
 	set g = SelectById(g, old_id[racial_peon], true)
-	set g = GetNearestSubGroupOfGroup(g, tower_target_loc, 3)  //g not destroyed memory leak - need to modify the code
+	set g = GetNearestSubGroupOfGroup(g, tower_target_loc, 3)
 
 	if (builder[1] == null or GetUnitState(builder[1], UNIT_STATE_LIFE) <= 0) and GetUnitCountDone(old_id[racial_peon]) > 7 then
 		set builder[1] = FirstOfGroup(g)

--- a/Jobs/WISP_CHECK.eai
+++ b/Jobs/WISP_CHECK.eai
@@ -2,7 +2,6 @@
 #ELSE
 function ElfMineCheck takes unit mine returns boolean
   local group g = CreateGroup()
-  local group tempg = null
   local location unitloc = GetUnitLoc(mine)
   local unit u = null
   local unit v = null
@@ -32,13 +31,9 @@ function ElfMineCheck takes unit mine returns boolean
     call GroupEnumUnitsOfPlayer(g, ai_player, null)
     set g = SelectByLoaded(g, false)
     set g = SelectNumberOfId(g, 100, old_id[race_manual_loading_wisp])
-	set tempg = CopyGroup(g)
-	call DestroyGroup(g)
-    set g = GetNearestSubGroupOfGroup(tempg, unitloc, delaywisps - i)
-	//call GroupRemoveGuardPositionInstant(g) // this gets wisps to come off the trees.
+    set g = GetNearestSubGroupOfGroup(g, unitloc, delaywisps - i)
+    //call GroupRemoveGuardPositionInstant(g) // this gets wisps to come off the trees.
     call GroupTargetOrder(g, "harvest", mine)
-	call DestroyGroup(tempg)
-	set tempg = null
   endif
   call RemoveLocation(unitloc)
   set unitloc = null

--- a/common.eai
+++ b/common.eai
@@ -3469,10 +3469,11 @@ endfunction
 //==========================================================================
 // (AMAI)	SelectNumberOfId
 //==========================================================================
-function SelectNumberOfId takes group g, integer n, integer id returns group
+function SelectNumberOfId takes group rg, integer n, integer id returns group
   local integer c = 0
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3484,6 +3485,7 @@ function SelectNumberOfId takes group g, integer n, integer id returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   set u = null
   return rg
 endfunction
@@ -3491,9 +3493,10 @@ endfunction
 //==========================================================================
 // (AMAI)	SelectById
 //==========================================================================
-function SelectById takes group g, integer id, boolean is_id returns group
+function SelectById takes group rg, integer id, boolean is_id returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3503,16 +3506,18 @@ function SelectById takes group g, integer id, boolean is_id returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByIdOr
 //==========================================================================
-function SelectByIdOr takes group g, integer id1, integer id2, boolean is_id returns group
+function SelectByIdOr takes group rg, integer id1, integer id2, boolean is_id returns group
   local integer id = 0
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3523,15 +3528,17 @@ function SelectByIdOr takes group g, integer id1, integer id2, boolean is_id ret
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectUnittype
 //==========================================================================
-function SelectUnittype takes group g, unittype typ, boolean is_of_type returns group
+function SelectUnittype takes group rg, unittype typ, boolean is_of_type returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3541,15 +3548,17 @@ function SelectUnittype takes group g, unittype typ, boolean is_of_type returns 
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByIllusion
 //==========================================================================
-function SelectByIllusion takes group g, boolean is_illusion returns group
+function SelectByIllusion takes group rg, boolean is_illusion returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3559,15 +3568,17 @@ function SelectByIllusion takes group g, boolean is_illusion returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByLoaded
 //==========================================================================
-function SelectByLoaded takes group g, boolean is_loaded returns group
+function SelectByLoaded takes group rg, boolean is_loaded returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3577,12 +3588,14 @@ function SelectByLoaded takes group g, boolean is_loaded returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByHidden takes group g, boolean is_visible returns group
+function SelectByHidden takes group rg, boolean is_visible returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3592,15 +3605,17 @@ function SelectByHidden takes group g, boolean is_visible returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByAlive
 //==========================================================================
-function SelectByAlive takes group g, boolean is_alive returns group
+function SelectByAlive takes group rg, boolean is_alive returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3611,12 +3626,14 @@ function SelectByAlive takes group g, boolean is_alive returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByAlive2 takes group g, boolean is_alive returns group
+function SelectByAlive2 takes group rg, boolean is_alive returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3627,13 +3644,15 @@ function SelectByAlive2 takes group g, boolean is_alive returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 // This function is used in the harrass code and only affects units (not heroes)
-function SelectByFullHealth takes group g, boolean is_healed returns group
+function SelectByFullHealth takes group rg, boolean is_healed returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3644,15 +3663,17 @@ function SelectByFullHealth takes group g, boolean is_healed returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByPlayer
 //==========================================================================
-function SelectByPlayer takes group g, player p, boolean is_owner returns group
+function SelectByPlayer takes group rg, player p, boolean is_owner returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3662,12 +3683,14 @@ function SelectByPlayer takes group g, player p, boolean is_owner returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByInvisible takes group g, player enemy, boolean is_visible returns group
+function SelectByInvisible takes group rg, player enemy, boolean is_visible returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3677,12 +3700,14 @@ function SelectByInvisible takes group g, player enemy, boolean is_visible retur
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByVisible takes group g, player  enemy, boolean is_visible returns group
+function SelectByVisible takes group rg, player enemy, boolean is_visible returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3692,12 +3717,14 @@ function SelectByVisible takes group g, player  enemy, boolean is_visible return
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByDetected takes group g, player enemy, boolean is_detected returns group
+function SelectByDetected takes group rg, player enemy, boolean is_detected returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3707,15 +3734,17 @@ function SelectByDetected takes group g, player enemy, boolean is_detected retur
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction 
 
 //==========================================================================
 // (AMAI)	SelectByEnemy
 //==========================================================================
-function SelectByEnemy takes group g, player p, boolean is_enemy returns group
+function SelectByEnemy takes group rg, player p, boolean is_enemy returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3725,6 +3754,7 @@ function SelectByEnemy takes group g, player p, boolean is_enemy returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
@@ -3732,16 +3762,33 @@ endfunction
 // (AMAI)	SelectByUserData
 //==========================================================================
 function IsStandardUnit takes unit u returns boolean
-	return (not IsUnitInGroup(u, unit_healing) and not IsUnitInGroup(u, unit_rescueing ) and not IsUnitInGroup(u, unit_harassing ) and not IsUnitInGroup(u, unit_zepplin_move ))
+  if IsUnitInGroup(u, unit_healing) then
+    return false
+  elseif IsUnitInGroup(u, unit_rescueing) then
+    return false
+  elseif IsUnitInGroup(u, unit_harassing) then
+    return false
+  elseif IsUnitInGroup(u, unit_zepplin_move) then
+    return false
+  endif
+  return true
 endfunction
 
 function IsUnitBuying takes unit u returns boolean
-	return IsUnitInGroup(u, unit_buying_tavern) or IsUnitInGroup(u, unit_buying_merc) or IsUnitInGroup(u, unit_buying_item)
+  if IsUnitInGroup(u, unit_buying_item) then
+    return true
+  elseif IsUnitInGroup(u, unit_buying_merc) then
+    return true
+  elseif IsUnitInGroup(u, unit_buying_tavern) then
+    return true
+  endif
+  return false
 endfunction
 
-function SelectByUnitStandard takes group g, boolean has_data returns group
+function SelectByUnitStandard takes group rg, boolean has_data returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3751,12 +3798,14 @@ function SelectByUnitStandard takes group g, boolean has_data returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByUnitFree takes group g, boolean has_data returns group
+function SelectByUnitFree takes group rg, boolean has_data returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3766,15 +3815,17 @@ function SelectByUnitFree takes group g, boolean has_data returns group
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //==========================================================================
 // (AMAI)	SelectByOrder
 //==========================================================================
-function SelectByOrder takes group g, integer my_order, boolean has_order returns group
+function SelectByOrder takes group rg, integer my_order, boolean has_order returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3784,14 +3835,16 @@ function SelectByOrder takes group g, integer my_order, boolean has_order return
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
 //============================================================================
-function SelectByOrderOr takes group g, integer my_order1, integer my_order2, boolean has_order returns group
+function SelectByOrderOr takes group rg, integer my_order1, integer my_order2, boolean has_order returns group
   local integer order = 0
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3802,13 +3855,15 @@ function SelectByOrderOr takes group g, integer my_order1, integer my_order2, bo
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
-function SelectByOrderOr2 takes group g, integer my_order1, integer my_order2, integer my_order3, boolean has_order returns group
+function SelectByOrderOr2 takes group rg, integer my_order1, integer my_order2, integer my_order3, boolean has_order returns group
   local integer order = 0
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3819,15 +3874,17 @@ function SelectByOrderOr2 takes group g, integer my_order1, integer my_order2, i
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 	
 //==========================================================================
 // (AMAI)	SelectByLocation
 //==========================================================================
-function SelectByLocation takes group g, location l, real dist, boolean is_near returns group
+function SelectByLocation takes group rg, location l, real dist, boolean is_near returns group
   local unit u = null
-  local group rg = CreateGroup()
+  local group g = rg
+  set rg = CreateGroup()
   loop
     set u = FirstOfGroup(g)
     exitwhen u == null
@@ -3837,6 +3894,7 @@ function SelectByLocation takes group g, location l, real dist, boolean is_near 
     call GroupRemoveUnit(g, u )
   endloop
   call DestroyGroup(g)
+  set g = null
   return rg
 endfunction
 
@@ -4133,11 +4191,13 @@ endfunction
 // endfunction
 
 function CreatePathingUnitFull takes unit u, player p, integer id, real x, real y returns unit
-  set u = CreateUnit(ai_player, id, x, y, 270.00) // player overriden as neutral players cannot be used
-  call SetUnitInvulnerable(u, true)
+  set u = CreateUnit(p, id, x, y, 270.00)
   if (not debugging) then
     call ShowUnit(u, false)
   endif
+  call UnitShareVision(u, ai_player, false)
+  call SetUnitInvulnerable(u, true)
+  call SetUnitOwner(u, ai_player, true)
   call SetUnitUseFood(u, false)
   call SetUnitMoveSpeed(u, 522)
   call RemoveGuardPosition(u)
@@ -4812,26 +4872,28 @@ function GetDensities takes location l, player p, real r returns nothing
     endif
     call GroupRemoveUnit(g, u)
   endloop
-  call RemoveLocation(ally_density_loc)
   if ally_density > 0 then
     set xa = xa / ally_density
     set ya = ya / ally_density
-    set ally_density_loc = Location(xa,ya)
     //set ally_density_loc = GetDivisionLoc_d(ally_density_loc, ally_density)
   else
-    set ally_density_loc = Location(0,0)
+    set xa = 0
+    set ya = 0
   endif
-  call RemoveLocation(enemy_density_loc)
+  call RemoveLocation(ally_density_loc)
+  set ally_density_loc = Location(xa,ya)
   if enemy_density > 0 then
     set xe = xe / enemy_density
     set ye = ye / enemy_density
-    set enemy_density_loc = Location(xe,ye)
     //set enemy_density_loc = GetDivisionLoc_d(enemy_density_loc, enemy_density)
   else
-    set enemy_density_loc = Location(0,0)
+    set xe = 0
+    set ye = 0
   endif
+  call RemoveLocation(enemy_density_loc)
+  set enemy_density_loc = Location(xe,ye)
   call DestroyGroup(g)
-  set g = null  
+  set g = null
   set ul = null
   set loc = null
 endfunction
@@ -5192,7 +5254,10 @@ endfunction
 
 //============================================================================
 function IsUnitTower takes unit u returns boolean
-  return IsUnitType(u, UNIT_TYPE_STRUCTURE) == true and IsUnitType(u, UNIT_TYPE_RANGED_ATTACKER) == true and not IsUnitHidden(u)
+  if IsUnitType(u, UNIT_TYPE_STRUCTURE) == true and IsUnitType(u, UNIT_TYPE_RANGED_ATTACKER) == true and not IsUnitHidden(u) then
+    return true
+  endif
+  return false
 endfunction
 
 //============================================================================
@@ -5680,30 +5745,28 @@ function CheckExpansionTaken takes unit expa returns boolean
   call GroupEnumUnitsInRange(g, GetUnitX(expa), GetUnitY(expa), expansion_taken_radius, null)
   set g = SelectByPlayer(g, Player(PLAYER_NEUTRAL_PASSIVE), false)
   set g = SelectUnittype(g, UNIT_TYPE_STRUCTURE, true)
-  // set g = SelectByAlive(g, true)
+  //set g = SelectByAlive(g, true)
   set g = SelectByAlive2(g, true)
-  if BlzGroupGetSize(g) > 1 then
-    call GroupRemoveUnit(g, expa)
-    loop
-      set u = FirstOfGroup(g)
-      exitwhen u == null
-      if GetUnitTypeId(u) == old_id[racial_expansion] or IsUnitType(u,UNIT_TYPE_TOWNHALL) then
-        call DestroyGroup(g)
-        set g = null
-        set u = null
-        if not IsUnitHidden(u) then
-          call GroupRemoveUnit(far_expansion, expa)
-        endif
-        return true
-      elseif GetOwningPlayer(u) != ai_player and GetOwningPlayer(u) != Player(PLAYER_NEUTRAL_AGGRESSIVE) then		// Creeps dosn't mean expansion is taken
-        call DestroyGroup(g)
-        set g = null
-        set u = null
-        return true
+  call GroupRemoveUnit(g, expa)
+  loop
+    set u = FirstOfGroup(g)
+    exitwhen u == null
+    if GetUnitTypeId(u) == old_id[racial_expansion] or IsUnitType(u,UNIT_TYPE_TOWNHALL) then
+      call DestroyGroup(g)
+      set g = null
+      set u = null
+      if not IsUnitHidden(u) then
+        call GroupRemoveUnit(far_expansion, expa)
       endif
-      call GroupRemoveUnit(g, u)
-    endloop
-  endif
+      return true
+    elseif GetOwningPlayer(u) != ai_player and GetOwningPlayer(u) != Player(PLAYER_NEUTRAL_AGGRESSIVE) then		// Creeps dosn't mean expansion is taken
+      call DestroyGroup(g)
+      set g = null
+      set u = null
+      return true
+    endif
+    call GroupRemoveUnit(g, u)
+  endloop
   call DestroyGroup(g)
   set g = null
   return false
@@ -6266,16 +6329,15 @@ endfunction
 function ChooseExpansion takes nothing returns nothing
   local integer i = 0
   local integer exp_chosen = 0
-
   set exp_number = 0
   loop
     exitwhen i >= expansion_list_length
-    if GetResourceAmount(expansion_list[i]) > 2 * GetUnitGoldCost2(racial_expansion) and not CheckExpansionTaken(expansion_list[i]) then
+    if GetResourceAmount(expansion_list[i]) > 2 * GetUnitGoldCost2(racial_expansion) and not CheckExpansionTaken(expansion_list[i]) and DistanceBetweenPoints_kd(home_location,GetUnitLoc(expansion_list[i])) > 1500 then
       call add_exp(expansion_list[i], expansion_dist[i], expansion_ancient[i], expansion_creeps[i])
     endif
     set i = i + 1
   endloop
-  if TownCountDone(neutral_zeppelin) > 0 then
+  if exp_number < 3 and TownCountDone(neutral_zeppelin) > 0 then  //first taken normal mine
     set i = 0
     loop
       exitwhen i >= water_expansion_list_length
@@ -6284,9 +6346,6 @@ function ChooseExpansion takes nothing returns nothing
       endif
       set i = i + 1
     endloop
-  endif
-  if active_expansion and exp_number < c_enemy_total + c_ally_total + 1 then
-    set active_expansion = false
   endif
   call add_exp_rp()
 //  call make_exp_rp_positive()
@@ -6319,7 +6378,6 @@ function GetExpFoe takes nothing returns unit
   set g = null
   //call Trace("Have a foe")
   return u
-
 endfunction
 
 function GetNeutralGuard takes integer nn returns boolean
@@ -7187,6 +7245,9 @@ if neutral_available[nn] == true then
   set neutral_night_buy[nn] = CanCreepGuardsSleep(nn)
   if neutral_guarded[nn] then
     call TQAddJob(30 * sleep_multiplier, NEUTRAL_GUARDED, nn)
+    if nn == NEUTRAL_TAVERN and hero[1] != 0 and buy_type[hero[1]] == BT_NEUTRAL_HERO then  //guarantee to train Ownrace hero at the first time
+      set recalculate_heros = true
+    endif
   endif
 endif
 endfunction
@@ -7238,6 +7299,9 @@ function PathingThread takes nothing returns nothing
   set pathing_done = true
   loop // no need repeated run
     call Sleep(6 * sleep_multiplier)
+    if active_expansion and exp_number < c_enemy_total + c_ally_total + 1 then
+      set active_expansion = false
+    endif
     if t == 5 then
       loop
         exitwhen i >= NEUTRAL_COUNT
@@ -7552,7 +7616,6 @@ endfunction
 function cmd_loop takes nothing returns nothing
   local integer cmd = 0
   local integer data = 0
-
   call StaggerSleep(0,3)
   call Trace("Starting Commander Thread Loop" )
   
@@ -8004,7 +8067,6 @@ function InitAMAI takes nothing returns nothing
   set mine_loc = GetUnitLoc(own_town_mine[0])
 
 //    call DebugSequenceStart("DebugRun")
-
 
 endfunction
 
@@ -8653,53 +8715,51 @@ endfunction
 //============================================================================
 
 function SetBuildAllAMCore takes integer t, integer qty, integer unitid, integer town, integer bloc, integer prio returns nothing
-    local integer i = 0
-    local integer j = 0
-
-    if unitid == 0 or qty == 0 then
+  local integer i = 0
+  local integer j = 0
+  if unitid == 0 or qty == 0 then
+    return
+  endif
+  if t == BUILD_UPGRADE then
+    if GetUpgradeLevel(old_id[unitid]) >= qty then
       return
     endif
-    
-    if t == BUILD_UPGRADE then
-      if GetUpgradeLevel(old_id[unitid]) >= qty then
-        return
-      endif
-    elseif t == BUILD_ITEM then
-      if GetItemNumber(unitid) >= qty then
-        return
-      endif
-    elseif TownCountTown(unitid, town) >= qty or (buy_type[unitid] > BT_RACIAL_ITEM and not neutral_available[GetNeutralNumber(unitid)]) then
+  elseif t == BUILD_ITEM then
+    if GetItemNumber(unitid) >= qty then
       return
     endif
-    call GetBuildLock()
+  elseif TownCountTown(unitid, town) >= qty or (buy_type[unitid] > BT_RACIAL_ITEM and not neutral_available[GetNeutralNumber(unitid)]) then
+    return
+  endif
+  call GetBuildLock()
   set j = Max(build_length - 1,0)
-    loop
-      exitwhen i >= build_length
-      exitwhen build_prio[i] < prio
-      if build_item[i] == unitid and build_qty[i] >= qty and build_town[i] == town then
-        call ReleaseBuildLock()
-        return
-      endif
-      set i = i + 1
-    endloop
-    loop
-      exitwhen j < i
-      set build_qty[j+1] = build_qty[j]
-      set build_type[j+1] = build_type[j]
-      set build_item[j+1] = build_item[j]
-      set build_town[j+1] = build_town[j]
-      set build_loc[j+1] = build_loc[j]
-      set build_prio[j+1] = build_prio[j]
-      set j = j - 1
-    endloop
-    set build_qty[i] = qty
-    set build_type[i] = t
-    set build_item[i] = unitid
-    set build_town[i] = town
-    set build_loc[i] = bloc
-    set build_prio[i] = prio
-    set build_length = build_length + 1
-    call ReleaseBuildLock()
+  loop
+    exitwhen i >= build_length
+    exitwhen build_prio[i] < prio
+    if build_item[i] == unitid and build_qty[i] >= qty and build_town[i] == town then
+      call ReleaseBuildLock()
+      return
+    endif
+    set i = i + 1
+  endloop
+  loop
+    exitwhen j < i
+    set build_qty[j+1] = build_qty[j]
+    set build_type[j+1] = build_type[j]
+    set build_item[j+1] = build_item[j]
+    set build_town[j+1] = build_town[j]
+    set build_loc[j+1] = build_loc[j]
+    set build_prio[j+1] = build_prio[j]
+    set j = j - 1
+  endloop
+  set build_qty[i] = qty
+  set build_type[i] = t
+  set build_item[i] = unitid
+  set build_town[i] = town
+  set build_loc[i] = bloc
+  set build_prio[i] = prio
+  set build_length = build_length + 1
+  call ReleaseBuildLock()
 
   if qty > 1 then
     call SetBuildAllAMCore(t, qty - 1, unitid, town, bloc, prio + prio_q_inc )
@@ -8708,58 +8768,58 @@ function SetBuildAllAMCore takes integer t, integer qty, integer unitid, integer
 endfunction
 
 function RefreshNeeded takes integer t, integer qty, integer unitid, integer town, integer bloc, integer prio returns nothing
-    if buy_type[unitid] == BT_ML_UPGRADE then
-      if qty == 1 then
-        if needed1[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, Get_f_qty(qty, unitid, town), needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      elseif qty == 2 then
-        call SetBuildAllAMCore(BUILD_UPGRADE, 1, unitid, town, BLOC_STD, prio + prio_n_inc)
-        if needed2[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, 1, needed2[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      else
-        call SetBuildAllAMCore(BUILD_UPGRADE, 1, unitid, town, BLOC_STD, prio + prio_n_inc + prio_n_inc)
-        call SetBuildAllAMCore(BUILD_UPGRADE, 2, unitid, town, BLOC_STD, prio + prio_n_inc)
-        if needed3[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, 1, needed3[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      endif
-    elseif buy_type[unitid] == BT_HERO or buy_type[unitid] == BT_NEUTRAL_HERO then
-      if unitid == hero[1] or unitid == hero[2] or unitid == hero[3] then
-        if needed1[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, 1, needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      endif
-      if (unitid == hero[2] and not hero_built[2]) or (unitid == hero[3] and not hero_built[3]) then
-        if needed2[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, 1, needed2[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      endif
-      if unitid == hero[3] and not hero_built[3] then
-        if needed3[unitid] != 0 then
-          call SetBuildAllAMCore(BUILD_UNIT, 1, needed3[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
-      endif    
-    else
+  if buy_type[unitid] == BT_ML_UPGRADE then
+    if qty == 1 then
       if needed1[unitid] != 0 then
-        if needed3[unitid] == UPGRADED then
-          call SetBuildAllAMCore(BUILD_UNIT, qty + TownCountExForUpgrade(needed1[unitid],unitid,false,town), needed1[unitid], town, bloc, prio + prio_n_inc)
-        else
-          call SetBuildAllAMCore(BUILD_UNIT, Get_f_qty(qty, unitid, town), needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
-        endif
+        call SetBuildAllAMCore(BUILD_UNIT, Get_f_qty(qty, unitid, town), needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
       endif
+    elseif qty == 2 then
+      call SetBuildAllAMCore(BUILD_UPGRADE, 1, unitid, town, BLOC_STD, prio + prio_n_inc)
       if needed2[unitid] != 0 then
         call SetBuildAllAMCore(BUILD_UNIT, 1, needed2[unitid], -1, BLOC_STD, prio + prio_n_inc)
       endif
-      if needed3[unitid] != 0 and needed3[unitid] != UPGRADED then
+    else
+      call SetBuildAllAMCore(BUILD_UPGRADE, 1, unitid, town, BLOC_STD, prio + prio_n_inc + prio_n_inc)
+      call SetBuildAllAMCore(BUILD_UPGRADE, 2, unitid, town, BLOC_STD, prio + prio_n_inc)
+      if needed3[unitid] != 0 then
         call SetBuildAllAMCore(BUILD_UNIT, 1, needed3[unitid], -1, BLOC_STD, prio + prio_n_inc)
       endif
     endif
-  #INCLUDETABLE <$VER$\NeededExtra.txt> #EFR
-    if unitid == %1 then
-      call SetBuildAllAMCore(BUILD_%2, %3, %4, -1, BLOC_STD, prio + prio_n_inc)
+  elseif buy_type[unitid] == BT_HERO or buy_type[unitid] == BT_NEUTRAL_HERO then
+    if unitid == hero[1] or unitid == hero[2] or unitid == hero[3] then
+      if needed1[unitid] != 0 then
+        call SetBuildAllAMCore(BUILD_UNIT, 1, needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
+      endif
     endif
+    if (unitid == hero[2] and not hero_built[2]) or (unitid == hero[3] and not hero_built[3]) then
+      if needed2[unitid] != 0 then
+        call SetBuildAllAMCore(BUILD_UNIT, 1, needed2[unitid], -1, BLOC_STD, prio + prio_n_inc)
+      endif
+    endif
+    if unitid == hero[3] and not hero_built[3] then
+      if needed3[unitid] != 0 then
+        call SetBuildAllAMCore(BUILD_UNIT, 1, needed3[unitid], -1, BLOC_STD, prio + prio_n_inc)
+      endif
+    endif
+  else
+    if needed1[unitid] != 0 then
+      if needed3[unitid] == UPGRADED then
+        call SetBuildAllAMCore(BUILD_UNIT, qty + TownCountExForUpgrade(needed1[unitid],unitid,false,town), needed1[unitid], town, bloc, prio + prio_n_inc)
+      else
+        call SetBuildAllAMCore(BUILD_UNIT, Get_f_qty(qty, unitid, town), needed1[unitid], -1, BLOC_STD, prio + prio_n_inc)
+      endif
+    endif
+    if needed2[unitid] != 0 then
+      call SetBuildAllAMCore(BUILD_UNIT, 1, needed2[unitid], -1, BLOC_STD, prio + prio_n_inc)
+    endif
+    if needed3[unitid] != 0 and needed3[unitid] != UPGRADED then
+      call SetBuildAllAMCore(BUILD_UNIT, 1, needed3[unitid], -1, BLOC_STD, prio + prio_n_inc)
+    endif
+  endif
+  #INCLUDETABLE <$VER$\NeededExtra.txt> #EFR
+  if unitid == %1 then
+    call SetBuildAllAMCore(BUILD_%2, %3, %4, -1, BLOC_STD, prio + prio_n_inc)
+  endif
   #ENDINCLUDE
 endfunction
 
@@ -9117,20 +9177,20 @@ function InitHarass takes nothing returns nothing
 endfunction
 
 function AddHarass takes integer groupnum, integer qty, integer unitid returns nothing
-    if (harass_size[groupnum] < max_harass_groups ) then
-      set harass_qty[harass_size[groupnum]] = qty
-      set harass_units[harass_size[groupnum]] = unitid
-      set harass_size[groupnum] = harass_size[groupnum] + 1
-    else 
-      call Trace("ERROR: Too many harass unit groups added to harass group")
-    endif
+  if (harass_size[groupnum] < max_harass_groups ) then
+    set harass_qty[harass_size[groupnum]] = qty
+    set harass_units[harass_size[groupnum]] = unitid
+    set harass_size[groupnum] = harass_size[groupnum] + 1
+  else
+    call Trace("ERROR: Too many harass unit groups added to harass group")
+  endif
 endfunction
 
 function AddHarassUnittype takes integer groupnum, integer harassnum, group g, group harasser, integer key returns group
   local group cg = CopyGroup(g)
   local unit u = null
   local real player_sum = 0
-  set cg = SelectNumberOfId(cg, harass_qty[harassnum], old_id[harass_units[harassnum]])
+  set cg = SelectNumberOfId(cg, harass_qty[harassnum*max_harass_groups + groupnum], old_id[harass_units[harassnum*max_harass_groups + groupnum]])
   loop
     set u = FirstOfGroup(cg)
     exitwhen u == null
@@ -9626,10 +9686,10 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     //------------------------------------------------------------------------
     // if we have all we're asking for then make nothing
     //
-        set have_qty = Max(TownCountTown(unitid,town),max_order)
+    set have_qty = Max(TownCountTown(unitid,town),max_order)
 
     if have_qty >= ask_qty then
-        return BUILT_ALL
+      return BUILT_ALL
     endif
     set need_qty = ask_qty - have_qty
 
@@ -9641,32 +9701,32 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     set food_cost = GetFoodUsed(old_id[unitid])
 
     if gold_cost == 0 then
-        set afford_gold = need_qty
+      set afford_gold = need_qty
     else
-        set afford_gold = total_gold / gold_cost
+      set afford_gold = total_gold / gold_cost
     endif
     if afford_gold < need_qty then
-        set afford_qty = afford_gold
+      set afford_qty = afford_gold
     else
-        set afford_qty = need_qty
+      set afford_qty = need_qty
     endif
 
     if wood_cost == 0 then
-        set afford_wood = need_qty
+      set afford_wood = need_qty
     else
-        set afford_wood = total_wood / wood_cost
+      set afford_wood = total_wood / wood_cost
     endif
     if afford_wood < afford_qty then
-        set afford_qty = afford_wood
+      set afford_qty = afford_wood
     endif
 
     if food_cost == 0 then
-        set afford_food = need_qty
+      set afford_food = need_qty
     else
-        set afford_food = total_food / food_cost
+      set afford_food = total_food / food_cost
     endif
     if afford_food < afford_qty then
-        set afford_qty = afford_food
+      set afford_qty = afford_food
     endif
 
     //------------------------------------------------------------------------
@@ -9704,13 +9764,13 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     set total_food = total_food - food_cost * cost_qty
 
     if total_gold < 0 then
-        set total_gold = 0
+      set total_gold = 0
     endif
     if total_wood < 0 then
-        set total_wood = 0
+      set total_wood = 0
     endif
     if total_food < 0 then
-        set total_food = 0
+      set total_food = 0
     endif
 
     // if we're waiting on gold and wood; pause build orders
@@ -9719,7 +9779,7 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     elseif total_wood <= 0 and not (wood_cost == 0) then
       return NOT_ENOUGH_RES
     elseif afford_qty <= 0 then
-        return BUILT_SOME
+      return BUILT_SOME
     endif
 
     //------------------------------------------------------------------------
@@ -10085,10 +10145,10 @@ function StartEmergencyItem takes integer ask_qty, integer itemid returns intege
   endif
 
   if nearest_neutral[NEUTRAL_MERCHANT] == null and buy_type[itemid] == BT_MERCHANT_ITEM then
-      call Trace("No merchant available to buy emergency item")
-     // Cannot path so will require transporter
-     // NYI
-     return BUILT_ALL
+    call Trace("No merchant available to buy emergency item")
+    // Cannot path so will require transporter
+    // NYI
+    return BUILT_ALL
   endif
 
   if available_time[itemid] > ai_time or (buy_type[itemid] == BT_MERCHANT_ITEM and neutral_guarded[NEUTRAL_MERCHANT] and ((daytime >= 5 and daytime < 18) or not neutral_night_buy[NEUTRAL_MERCHANT])) then
@@ -10098,8 +10158,8 @@ function StartEmergencyItem takes integer ask_qty, integer itemid returns intege
   if (needed1[itemid] != 0 and TownCountDone(needed1[itemid]) < 1) or (needed2[itemid] != 0 and TownCountDone(needed2[itemid]) < 1) or (needed3[itemid] != 0 and TownCountDone(needed3[itemid]) < 1) then
     call Trace("Emergency item not enough requirements to buy item")
     return CANNOT_BUILD
-  endif  
-  
+  endif
+
   set gold = gold - gold_cost
   set wood = wood - wood_cost
 
@@ -10238,12 +10298,12 @@ function PeonBuilder takes nothing returns nothing
     set sc = 0
   endif
   //if w <= maximum_peon_wood then 
-  /// call BuildPeons( peon_1_mine_number * mo + Max(max_lumber_peons - shredder_peon_count*sc, 1 )  )  // number of peons per mine + wood peons
+  //  call BuildPeons( peon_1_mine_number * mo + Max(max_lumber_peons - shredder_peon_count*sc, 1 )  )  // number of peons per mine + wood peons
   //elseif w >= minimum_peon_wood then
-  // call BuildPeons( peon_1_mine_number * mo + Max(min_lumber_peons - shredder_peon_count*sc, 1 )  )
- // else
- //  call BuildPeons( peon_1_mine_number * mo + Max(Max(min_lumber_peons, R2I(I2R(max_lumber_peons) / 2)) - shredder_peon_count*sc, 1 )  )
- // endif
+  //  call BuildPeons( peon_1_mine_number * mo + Max(min_lumber_peons - shredder_peon_count*sc, 1 )  )
+  //else
+  //  call BuildPeons( peon_1_mine_number * mo + Max(Max(min_lumber_peons, R2I(I2R(max_lumber_peons) / 2)) - shredder_peon_count*sc, 1 )  )
+  //endif
 
   if race_has_ghouls then
     if mo <= 1 then
@@ -10400,7 +10460,7 @@ function CheckUnitNewTown takes unit u, integer num returns boolean
   local location l = GetUnitLoc(u)
   loop
     exitwhen i >= num
-    if own_town_loc[i] != null and town_built[i] and DistanceBetweenPoints(l, own_town_loc[i]) < town_radius then
+    if town_built[i] and own_town_loc[i] != null and DistanceBetweenPoints(l, own_town_loc[i]) < town_radius then
       call RemoveLocation(l)
       set l = null
       return false
@@ -10548,7 +10608,7 @@ function OneBuildLoopAM takes nothing returns nothing
     local integer tracednoresources = 0
     local integer tracedall = 0
     local string logtype = ""
-    
+
     call InitLastUpkeep()
 
     call TimeKeeper()
@@ -10560,7 +10620,6 @@ function OneBuildLoopAM takes nothing returns nothing
       call ExpansionBuilder()
       call HeroReviver()
     endif
-
     set total_gold   = GetGold() - gold_buffer
     set total_wood   = GetWood() - wood_buffer
     set total_food   = ver_food_limit - FoodUsed()
@@ -10982,7 +11041,7 @@ function CommonSleepUntilTargetDeadAM takes unit target, boolean iscreeping, boo
     set attack_length_counter = 5000  // Force army to regroup to try and get ghouls to go along
   endif
   loop
-    exitwhen town_threat_break and town_threatened and town_threat[most_threatened_town] >= teleport_low_threat and not desperation_assault
+    exitwhen town_threat_break and town_threatened and most_threatened_town >= 0 and town_threat[most_threatened_town] >= teleport_low_threat and not desperation_assault
     exitwhen break_attack and not desperation_assault
     //exitwhen captain_flee and CaptainRetreating()
     exitwhen isfleeing and CaptainRetreating() and not desperation_assault
@@ -11073,7 +11132,7 @@ endfunction
 function SleepUntilAtGoalAM takes nothing returns nothing
   local integer lcount = 0
   loop
-    exitwhen town_threatened and town_threat[most_threatened_town] >= teleport_low_threat
+    exitwhen town_threatened and most_threatened_town >= 0 and town_threat[most_threatened_town] >= teleport_low_threat
     set lcount = lcount + 1
     call Sleep(sleep_multiplier)
       exitwhen break_attack
@@ -11210,7 +11269,7 @@ endfunction
 //============================================================================
 function AttackMoveTowerRush takes nothing returns nothing
 	local integer attack_length_counter = 0
-	set attack_running = true	
+	set attack_running = true
 	loop
 		exitwhen not towerrush
 		exitwhen town_threatened and town_threat[most_threatened_town] >= teleport_low_threat
@@ -11775,7 +11834,6 @@ endfunction
 //============================================================================
 function SleepUntilTownDefended takes integer ai_strength returns nothing
 	local integer defense_length_counter = 0
-
 	set own_strength = ai_strength
 	call Trace("==Sleep Defend Town==" )
 	loop
@@ -11830,6 +11888,7 @@ function SetLeadAlly takes nothing returns nothing
     set i = i + 1
   endloop
 endfunction
+
 //============================================================================
 // AMAI SingleMeleeAttack
 //============================================================================
@@ -11838,7 +11897,6 @@ function SingleMeleeAttackAM takes boolean needs_exp, boolean has_siege, boolean
   local unit mega = null
   local unit creep = null
   local unit common = null
-
 
 //call Trace("SingleMeleeAttack")
 
@@ -12113,7 +12171,7 @@ function SingleMeleeAttackAM takes boolean needs_exp, boolean has_siege, boolean
         set mega = GetMegaTarget()
         if mega != null and UnitAlive(mega) then
           call Trace("Mega Attack Target")
-          call SetAllianceTarget(mega)		
+          call SetAllianceTarget(mega)
           call SetChatVarsAttack(mega)
           call Chat(C_Mega)
           call Chat(C_Megatarget)
@@ -12358,7 +12416,6 @@ function ApplyHealingItem takes unit u, item heal_item returns nothing
 	local unit target = null
 	local group urgent = null
 	local group medium = null
-
 	set urgent = CopyGroup(urgent_healing_group)
 	set medium = CopyGroup(medium_healing_group)
 	call RemoveGuardPosition(u)
@@ -12465,9 +12522,8 @@ function HealArmy takes nothing returns nothing
         if hs <= healthTrigger then
           call Sleep(8*sleep_multiplier) // Wait some time for item to be bought
         endif
-      endif  
+      endif
     endif
-
     call Sleep(2 * sleep_multiplier)
     exitwhen hs > healthTrigger // Still a large proportion of army is strong so exit loop
   endloop
@@ -12534,7 +12590,7 @@ function universal_attack_sequence takes nothing returns nothing
 
   if go_home then
     call Trace("UNIVERSAL ATTACK: Going home" )
-    call ClearCaptainTargets() 
+    call ClearCaptainTargets()
     call CaptainGoHome()
   endif
   set break_attack = false
@@ -12549,73 +12605,75 @@ endfunction
 // (AMAI) Universal peon assignment
 //============================================================================
 function universal_peon_assignment takes nothing returns nothing
-    local integer T = TownWithMine()
-    local integer g = GetGold()
-    local integer w = GetWood()
-    local integer pwh = 0
-    local integer swh = 0
-    local real gdivw = I2R(g)/I2R(Max(w,1))
-    local integer i = T + 1
+  local integer T = TownWithMine()
+  local integer g = GetGold()
+  local integer w = GetWood()
+  local integer pwh = 0
+  local integer swh = 0
+  local real gdivw = I2R(g)/I2R(Max(w,1))
+  local integer i = T + 1
 
-    if T < 0 then
-      set T = 0
-      set i = 1
-    endif
+  if T < 0 then
+    set T = 0
+    set i = 1
+  endif
 
-    if g - w > 300 then
-      set pwh = 2
-    elseif g - w > 500 and w < 100 then
-      set pwh = 5
-    elseif g - w > 900 and w < 200 then
-      set pwh = 8
-    else
-      set pwh = 2
-    endif
+  if g - w > 300 then
+    set pwh = 2
+  elseif g - w > 500 and w < 100 then
+    set pwh = 5
+  elseif g - w > 900 and w < 200 then
+    set pwh = 8
+  else
+    set pwh = 2
+  endif
 
-    if w < 200 then
-      set swh = 6 - pwh
-    elseif gdivw < 0.5 then
-      set swh = 0
-    elseif gdivw < 0.8 then
-      set swh = Max(1 - pwh,0)
-    elseif gdivw < 1.1 then
-      set swh = Max(2 - pwh,0)
-    elseif gdivw < 1.4 then
-      set swh = Max(3 - pwh,0)
-    elseif gdivw < 1.7 then
-      set swh = Max(4 - pwh,0)
-    elseif gdivw < 2.0 then
-      set swh = Max(5 - pwh,0)
-    else
-      set swh = Max(6 - pwh,0)
-    endif
+  if w < 200 then
+    set swh = 6 - pwh
+  elseif gdivw < 0.5 then
+    set swh = 0
+  elseif gdivw < 0.8 then
+    set swh = Max(1 - pwh,0)
+  elseif gdivw < 1.1 then
+    set swh = Max(2 - pwh,0)
+  elseif gdivw < 1.4 then
+    set swh = Max(3 - pwh,0)
+  elseif gdivw < 1.7 then
+    set swh = Max(4 - pwh,0)
+  elseif gdivw < 2.0 then
+    set swh = Max(5 - pwh,0)
+  else
+    set swh = Max(6 - pwh,0)
+  endif
 
-    set swh = Max(swh - 4 * TownCountDone(neutral_shredder),0)
+  set swh = Max(swh - 4 * TownCountDone(neutral_shredder),0)
 
-    call ClearHarvestAI()
+  call ClearHarvestAI()
 
-    if (desperation_assault) then
-      return
-    endif
+  if (desperation_assault) then
+    return
+  endif
 
-    call HarvestGold(T,ver_optimal_gold)
-    call HarvestWood(0,pwh)
-    call HarvestWood(0,swh)
+  call HarvestGold(T,ver_optimal_gold - 1)
+  call HarvestWood(0,1)
+  call HarvestGold(T,1)
+  call HarvestWood(0,pwh)
+  call HarvestWood(0,swh)
 
-    loop
-      //set i = i + 1
-      exitwhen i > T + 3
-      if T != i and TownHasMine(i) and TownCountEx(racial_expansion,true,i) > 0 then
-        if gdivw < 3.0 or g < 300 then
-          call HarvestGold(i,ver_optimal_gold)
-        else
-          call HarvestGold(i,ver_optimal_gold - 2)
-        endif
+  loop
+    //set i = i + 1
+    exitwhen i > Max(T + 3,TownCountDone(racial_expansion))
+    if T != i and TownHasMine(i) and TownCountEx(racial_expansion,true,i) > 0 then
+      if gdivw < 3.0 or g < 300 then
+        call HarvestGold(i,ver_optimal_gold)
+      else
+        call HarvestGold(i,ver_optimal_gold - 2)
       endif
-      set i = i + 1
-    endloop
+    endif
+    set i = i + 1
+  endloop
 
-    call HarvestWood(0,20)
+  call HarvestWood(0,20)
 endfunction
 
 //============================================================================
@@ -12650,7 +12708,7 @@ function AddWaveResources takes nothing returns nothing
   endloop
 
   call IncreaseAIResources(g,w)
-  
+
 endfunction
 
 //============================================================================
@@ -14263,7 +14321,6 @@ endfunction
 //============================================================================
 function SkillArrays takes nothing returns integer
     local integer level = GetHeroLevelAI()
-
     if level > max_hero_level then
         set max_hero_level = level
     endif
@@ -14336,12 +14393,10 @@ function PickMeleeHero takes race raceid returns integer
     local integer last
     local integer array heroes
     local integer i
-
 #INCLUDETABLE <$VER$\GlobalSettings.txt> #EFR #COND '%1' eq 'ver_neutral_hero_number' 
     set %1 = %2
 #ENDINCLUDE
-    call InitAiUnits()	// This function makes all unit ids go back to there originals
-
+    call InitAiUnits()  // This function makes all unit ids go back to there originals
     set i = ver_neutral_hero_number
     //------------------------------------------------------------------------
     if raceid == RACE_HUMAN then

--- a/common.eai
+++ b/common.eai
@@ -4200,11 +4200,11 @@ function CreatePathingUnitFull takes unit u, player p, integer id, real x, real 
   endif
   call UnitShareVision(u, ai_player, false)
   call SetUnitInvulnerable(u, true)
+  call SetUnitUseFood(u, false)
+  call SetUnitMoveSpeed(u, 522)
   if p != ai_player then
     call SetUnitOwner(u, ai_player, true)  // player overriden as neutral players cannot be used
   endif
-  call SetUnitUseFood(u, false)
-  call SetUnitMoveSpeed(u, 522)
   call RemoveGuardPosition(u)
   return u
 endfunction

--- a/common.eai
+++ b/common.eai
@@ -4191,7 +4191,7 @@ endfunction
 // endfunction
 
 function CreatePathingUnitFull takes unit u, player p, integer id, real x, real y returns unit
-  if not IsVisibleToPlayer(x, y, p) and p != Player(PLAYER_NEUTRAL_PASSIVE) then
+  if not IsVisibleToPlayer(x, y, ai_player) and p != Player(PLAYER_NEUTRAL_PASSIVE) then
     set p = Player(PLAYER_NEUTRAL_PASSIVE)
   endif
   set u = CreateUnit(p, id, x, y, 270.00)

--- a/common.eai
+++ b/common.eai
@@ -4191,13 +4191,18 @@ endfunction
 // endfunction
 
 function CreatePathingUnitFull takes unit u, player p, integer id, real x, real y returns unit
+  if not IsVisibleToPlayer(x, y, p) and p != Player(PLAYER_NEUTRAL_PASSIVE) then
+    set p = Player(PLAYER_NEUTRAL_PASSIVE)
+  endif
   set u = CreateUnit(p, id, x, y, 270.00)
   if (not debugging) then
     call ShowUnit(u, false)
   endif
   call UnitShareVision(u, ai_player, false)
   call SetUnitInvulnerable(u, true)
-  call SetUnitOwner(u, ai_player, true)  // player overriden as neutral players cannot be used
+  if p != ai_player then
+    call SetUnitOwner(u, ai_player, true)  // player overriden as neutral players cannot be used
+  endif
   call SetUnitUseFood(u, false)
   call SetUnitMoveSpeed(u, 522)
   call RemoveGuardPosition(u)

--- a/common.eai
+++ b/common.eai
@@ -11764,7 +11764,7 @@ endfunction
 //============================================================================
 function Militia_Expansion takes integer m returns nothing
   local group g = null
-  local group tempg = null
+  local group cg = null
   local unit u = null
   local unit efoe = GetExpFoe()
   local integer t = 0
@@ -11780,12 +11780,10 @@ function Militia_Expansion takes integer m returns nothing
   call GroupEnumUnitsOfPlayer(g, ai_player, null)
   set g = SelectNumberOfId(g, 100, old_id[racial_peon] )
   set g = SelectByAlive(g, true)
-  set tempg = GetNearestSubGroupOfGroup(g, home_location, m)
-  call DestroyGroup(g)
-  set g = null
-  //set expansion_peon = FirstOfGroup(tempg)
-  call AddAbilityToGroup(CopyGroup(tempg), race_militia_ability)
-  call GroupImmediateOrder(tempg, race_militia_unitstring)
+  set g = GetNearestSubGroupOfGroup(g, home_location, m)
+  //set expansion_peon = FirstOfGroup(g)
+  call AddAbilityToGroup(CopyGroup(g), race_militia_ability)
+  call GroupImmediateOrder(g, race_militia_unitstring)
   call RemoveInjuries()
   call FormGroupAM(4)
   loop
@@ -11823,8 +11821,9 @@ function Militia_Expansion takes integer m returns nothing
   //set captain_flee = true
   //set militia = false
   set take_exp = false
-  call DestroyGroup(tempg)
-  set tempg = null
+  call DestroyGroup(g)
+  set g = null
+  set cg = null
   set efoe = null
   set u = null
 endfunction

--- a/common.eai
+++ b/common.eai
@@ -6347,6 +6347,9 @@ function ChooseExpansion takes nothing returns nothing
       set i = i + 1
     endloop
   endif
+  if active_expansion and not pathing_done and exp_number < c_enemy_total + c_ally_total + 1 then
+    set active_expansion = false
+  endif
   call add_exp_rp()
 //  call make_exp_rp_positive()
   if exp_number == 0 then

--- a/common.eai
+++ b/common.eai
@@ -9193,7 +9193,7 @@ function AddHarassUnittype takes integer groupnum, integer harassnum, group g, g
   local group cg = CopyGroup(g)
   local unit u = null
   local real player_sum = 0
-  set cg = SelectNumberOfId(cg, harass_qty[harassnum*max_harass_groups + groupnum], old_id[harass_units[harassnum*max_harass_groups + groupnum]])
+  set cg = SelectNumberOfId(cg, harass_qty[harassnum], old_id[harass_units[harassnum]])
   loop
     set u = FirstOfGroup(cg)
     exitwhen u == null

--- a/common.eai
+++ b/common.eai
@@ -4197,7 +4197,7 @@ function CreatePathingUnitFull takes unit u, player p, integer id, real x, real 
   endif
   call UnitShareVision(u, ai_player, false)
   call SetUnitInvulnerable(u, true)
-  call SetUnitOwner(u, ai_player, true)
+  call SetUnitOwner(u, ai_player, true)  // player overriden as neutral players cannot be used
   call SetUnitUseFood(u, false)
   call SetUnitMoveSpeed(u, 522)
   call RemoveGuardPosition(u)


### PR DESCRIPTION
- Select group no longer returning local variables , excrete still not completed, will continue to submit
   - CopyGroup and not modified yet
- ChooseExpansion no take Mines that are too close to home_location 
- ChooseExpansion  first taken normal mine , not water mine
- active_expansion regular query of the migration path thread when pathing done
- check most_threatened_town is 0
- towerrush no run FastBuild and MilitiaExpansion
- recalculate_heros first time , if CheckNeutralQuick check NEUTRAL_TAVERN have Creep Guards , do recalculate_heros 
   - On certain maps, , NEUTRAL_TAVERN no Creep Guards , but high or low ground on the second floor near NEUTRAL_TAVERN have Creep Guards ,  second floor cannot go NEUTRAL_TAVERN , but some time the Guards having NEUTRAL_TAVERN 's view , will attack buy unit , and check CreepGuardsGorup function just take absolute distance , AI will think there have Guards 
- fix https://github.com/SMUnlimited/AMAI/issues/175
- try mitigation https://github.com/SMUnlimited/AMAI/issues/159  ,  but is not be very effective , If there are many units in the area , it will be too laggy when using the cycle traversal unit, which may require redoing some code


Text alignment (OCD)



I still believe that Zoom cannot function properly , Maybe we all need to check it out