### PR TITLE
fix ExpansionBuilder bug

### DIFF
--- a/common.eai
+++ b/common.eai
@@ -10837,6 +10837,7 @@ function ExpansionBuilder takes nothing returns nothing
 local integer mines = GetMinesOwned()
 local integer gold_left = GetGoldOwned()
 local integer i = racial_expansion
+local integer f = 0
 local boolean exp_prepared = false
 local boolean rebuild = false
 local unit u = null
@@ -10854,7 +10855,9 @@ if current_expansion == null or CheckExpansionTaken(current_expansion) then
 endif
 if CheckExpansionTaken(current_expansion) then
   call Trace("ExpansionBuilder: Expansion taken by someone else")
-  set current_expansion = null
+  if current_expansion != not_taken_expansion then
+    set current_expansion = null
+  endif
   return
 endif
 set exp_prepared = false
@@ -10881,7 +10884,7 @@ if mines < 2 and ai_time - exp_time_count > exp_first_time then
   endif
 endif
 
-if mines < 3 and ai_time - exp_time_count > exp_second_time or (active_expansion and ai_time - exp_time_count > exp_first_time) then
+if (mines < 3 and ai_time - exp_time_count > exp_second_time) or (active_expansion and ai_time - exp_time_count > exp_first_time) then
   if u != null then
     set take_exp = true
     call Trace("ExpansionBuilder:Need to Creep Mine 3")
@@ -10902,10 +10905,11 @@ endif
 set u = null
 
 set i = 0
+set f = FoodUsed() + 10
 loop
     exitwhen i >= UPKEEP_NUM or upkeepboost
     // If near on in an upkeep level that needs more mines then boost expansion priority
-    if mines < upkeep_mines_needed[i] and FoodUsed() > upkeep_border[i] - 10 then
+    if mines < upkeep_mines_needed[i] and f > upkeep_border[i] then
       set upkeepboost = true
     endif
     set i = i + 1


### PR DESCRIPTION
current_expansion  should check not_taken_expansion 
I think the `not_taken_expansion`  significance is let ExpansionBuilder and StartExpansionAM not take not_taken_expansion  , so on ExpansionBuilder and StartExpansionAM cannot set null when current_expansion  == not_taken_expansion  
https://github.com/SMUnlimited/AMAI/issues/244

_I am still adjusting the not_taken_expansion  logic, now just  know is that it has influenced MultipleMinefix_

now only can temporarily submit a repair `ai_time - exp_time_count > exp_second_time` judgment



--------------------------------------------------
`not_taken_expansion` is Completely different expansion logic , maybe can not use `ChooseExpansion` take ,  should be expanding beyond the `StartExpansionAM` logic of expansion, rather than expansion the same  `StartExpansionAM`  mine