### PR TITLE
skill fix only run on 1.29 ~ 1.32.9

### DIFF
--- a/REFORGED/custom_common.eai
+++ b/REFORGED/custom_common.eai
@@ -4,6 +4,7 @@ integer PLAYER_AMAI_NEUTRAL_PASSIVE             =  GetPlayerNeutralPassive()
 integer PLAYER_AMAI_NEUTRAL_AGGRESSIVE          =  GetPlayerNeutralAggressive()
 boolean   legacyCamera = false
 boolean   skillfix = false
+boolean AatpAbility = false
 
 #ELSE
 function VersionCheck takes nothing returns nothing

--- a/TFT/custom_common.eai
+++ b/TFT/custom_common.eai
@@ -19,8 +19,10 @@
     integer PLAYER_AMAI_NEUTRAL_AGGRESSIVE          =  12
     boolean   legacyCamera = true
     boolean skillfix = false
+    boolean AatpAbility = false
 #ELSE
 function VersionCheck takes nothing returns nothing
+    local unit u = null
     if GetPlayerController(Player(12)) != MAP_CONTROL_CREEP then
       set bj_MAX_PLAYERS_AMAI = 24
       set bj_MAX_PLAYER_SLOTS_AMAI = 26
@@ -40,8 +42,13 @@ function VersionCheck takes nothing returns nothing
       set PLAYER_COLOR_SNOW               = ConvertPlayerColor(21)
       set PLAYER_COLOR_EMERALD            = ConvertPlayerColor(22)
       set PLAYER_COLOR_PEANUT             = ConvertPlayerColor(23)
+      set u = CreateUnit(Player(PLAYER_AMAI_NEUTRAL_PASSIVE), 'ugar', 0, 0, 270.0)
+      call UnitAddAbility(u, 'Aatp')  //Prevent customization
+      set AatpAbility = GetUnitAbilityLevel(u, 'Aatp') > 0  // prevent old war3 or ROC
+      call RemoveUnit(u)
+      set u = null
     endif
-    if (JASS_MAX_ARRAY_SIZE > 8192) then  //1.29 ~ 1.31 or higher
+    if JASS_MAX_ARRAY_SIZE > 8192 and not AatpAbility then  //1.29 ~ 1.32.9
       set skillfix = true
     endif
 endfunction

--- a/common.eai
+++ b/common.eai
@@ -12947,10 +12947,7 @@ function SkillArraysAM takes nothing returns integer
   if level > max_hero_level then
     set max_hero_level = level
   endif
-  if skillfix == true then    //Assisted Hero Learning Skills , for war3 1.31 bug
-    if hero_unit[hn] == null then
-      set hero_unit[hn] = GetOneOfId(hero_unit[hn], ai_player, old_id[hero[hn]])
-    endif
+  if skillfix == true and hero_unit[hn] != null and UnitAlive(hero_unit[hn]) then    //Assisted Hero Learning Skills , for war3 1.31 bug
     call SelectHeroSkill(hero_unit[hn], skills[(hn - 1) * HERO_LEVEL_NUMBER + level])
   endif
   return skills[(hn - 1) * HERO_LEVEL_NUMBER + level]


### PR DESCRIPTION
Use some newly added skills to determine the version , Reduced skill fix run


`AatpAbility`  it can be used to switch the attack posture of the gargoyle ,  future

There is no way to obtain the version more accurately in the script, unless using the console as an aid, but not every player will install the console, so I think this is the best option