### PR TITLE
add racial_lumber build judgment the racial_expansion total 

### DIFF
--- a/HeroFleeRules.ai
+++ b/HeroFleeRules.ai
@@ -31,7 +31,7 @@
   call ActionRule(not race_has_moonwells or TownCountDone(racial_farm) <= 0, ACTION_MOONWELLS,-1000000)
   if nearest_neutral[hFountainID] != null then
     call ActionRule(DistanceBetweenPoints_dk(GetUnitLoc(nearest_neutral[hFountainID]),l) > DistanceBetweenPoints(home_location,l), ACTION_MOONWELLS, 18) // Use moonwells if they closer than the fountain
-  else
+  elseif race_has_moonwells then
     call ActionRule(true,ACTION_MOONWELLS, 18)
   endif
   call ActionRule2(follow_zeppelin == null or IsUnitInGroup(follow_zeppelin, unit_rescueing),  ACTION_ZEPPELIN_HOME, -1000000.0, ACTION_ZEPPELIN_FOUNTAIN, -1000000.0)

--- a/common.eai
+++ b/common.eai
@@ -10455,7 +10455,7 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     endif
 
   // Intentionally not using have_qty as the build lumber mill at base can not be picked up by the count as it builds somewhere else
-    if unitid == racial_lumber and GetUnitCount(old_id[unitid]) < 1 and town <= 0 then
+    if unitid == racial_lumber and ((GetUnitCount(old_id[unitid]) < 1 and town < 1) or (GetUnitCount(old_id[unitid]) < TownCountDone(racial_hall[1]) and town > 0)) then
       if BuildLumberMillAtBase() then
         return BUILT_SOME
       else

--- a/common.eai
+++ b/common.eai
@@ -10455,7 +10455,7 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     endif
 
   // Intentionally not using have_qty as the build lumber mill at base can not be picked up by the count as it builds somewhere else
-    if unitid == racial_lumber and ((GetUnitCount(old_id[unitid]) < 1 and town < 1) or (GetUnitCount(old_id[unitid]) < TownCountDone(racial_hall[1]) and town > 0)) then
+    if unitid == racial_lumber and ((GetUnitCount(old_id[unitid]) < 1 and town < 1) or (GetUnitCount(old_id[unitid]) < TownCount(racial_hall[1]) and town > 0)) then
       if BuildLumberMillAtBase() then
         return BUILT_SOME
       else

--- a/common.eai
+++ b/common.eai
@@ -10455,7 +10455,7 @@ function StartUnitAM takes integer ask_qty, integer unitid, integer town, intege
     endif
 
   // Intentionally not using have_qty as the build lumber mill at base can not be picked up by the count as it builds somewhere else
-    if unitid == racial_lumber and ((GetUnitCount(old_id[unitid]) < 1 and town < 1) or (GetUnitCount(old_id[unitid]) < TownCount(racial_hall[1]) and town > 0)) then
+    if unitid == racial_lumber and ((GetUnitCount(old_id[unitid]) < 1 and town < 1) or (GetUnitCount(old_id[unitid]) < TownCount(racial_expansion) and town > 0)) then
       if BuildLumberMillAtBase() then
         return BUILT_SOME
       else

--- a/common.eai
+++ b/common.eai
@@ -7425,7 +7425,7 @@ function TQHandleOnce takes nothing returns boolean
   set unit_par = null
   set group_par = null
   set unit_par2 = null
-  return false
+  return b
 endfunction
 
 //============================================================================

--- a/common.eai
+++ b/common.eai
@@ -11508,7 +11508,7 @@ function FormGroupAM takes integer seconds returns nothing
   call InitAssault()
 
   loop
-    exitwhen index == attack_length
+    exitwhen index >= attack_length
 
     set unitid = attack_units[index]
 


### PR DESCRIPTION
I think `lumber`  only need building one
if allow construction at `expansion`, it's not entirely accurate where to build it .  -- The problem he initially hoped to avoid has not been resolved, and ai may still create two at one expansion point

but  year ,  should allow construction at `expansion` , I really didn't consider this
