### PR TITLE
fix https://github.com/SMUnlimited/AMAI/issues/389

### DIFF
--- a/common.eai
+++ b/common.eai
@@ -11009,10 +11009,6 @@ if mines < 2 and ai_time - exp_time_count > exp_first_time then
   if u != null then
     set take_exp = true
     call Trace("ExpansionBuilder:Need to Creep Mine 2")
-    //if attacking_expansion then
-    //  set exp_prepared = true
-    //  call Trace("ExpansionBuilder: Ready to expand to mine 2 - odd")
-    //endif
   else
     set take_exp = false
     set exp_prepared = true
@@ -11020,7 +11016,7 @@ if mines < 2 and ai_time - exp_time_count > exp_first_time then
   endif
 endif
 
-if mines < 3 and ((ai_time - exp_time_count > exp_second_time) or (active_expansion and ai_time - exp_time_count > exp_first_time)) then
+if mines < 3 and ai_time - exp_time_count > exp_second_time then
   if u != null then
     set take_exp = true
     call Trace("ExpansionBuilder:Need to Creep Mine 3")
@@ -11050,16 +11046,22 @@ loop
     endif
     set i = i + 1
 endloop
+set i = 0
+if mines < 3 and active_expansion then
+  set exp_prepared = true
+  call Trace("ExpansionBuilder: Active expansion")
+  set i = Max(GetPlayerUnitTypeCount(Player(PLAYER_NEUTRAL_PASSIVE),'ngol') - (c_enemy_total + c_ally_total + 1), 20)
+endif
 
 if mines < 1 or gold_left < 2500 or exp_prepared then
   call Trace("ExpansionBuilder: Putting mine on build list")
   call CreateDebugTagLoc("Current Expansion", 10, GetUnitX(current_expansion), GetUnitY(current_expansion), 1.00, 0.80)
   if mines < 1 or gold_left < 2500 then
-    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_emergency_prio)
+    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_emergency_prio + i)
   elseif rebuild or upkeepboost then
-    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_rebuild_prio)
+    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_rebuild_prio + i)
   else
-    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_prio)
+    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_prio + i)
   endif
 else
   call Trace("ExpansionBuilder: Not ready to build mine")


### PR DESCRIPTION
Attention, actively expanding now is not limited by time

```
ai_time - exp_time_count > exp_first_time
ai_time - exp_time_count > exp_second_time
```

fix
https://github.com/SMUnlimited/AMAI/issues/316
https://github.com/SMUnlimited/AMAI/issues/389

_When this repair is completed, I plan to submit it as a significant change_
https://github.com/SMUnlimited/AMAI/issues/323

------------------------------------------------------------------------------------

I did not submit the chaotic expansion

If possible, please evaluate this feature first , Thank you.

```
_if mines < 1 or gold_left < 2500 or exp_prepared then
  call Trace("ExpansionBuilder: Putting mine on build list")
  call CreateDebugTagLoc("Current Expansion", 10, GetUnitX(current_expansion), GetUnitY(current_expansion), 1.00, 0.80)
  if mines < 1 or gold_left < 2500 then
    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_emergency_prio + i)
  elseif rebuild or upkeepboost then
    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_rebuild_prio + i)
  else
    call BuildExpa(TownCount(racial_expansion) + 1, racial_expansion, expa_prio + i)
  endif
  return_
elseif active_expansion and mines < 4 and GetRandomInt(0, 100 - i) < 42 and GetGold() > 1000 and GetWood() > 700 and not_taken_expansion == null then
  if chaos_expansion != null and chaos_expansion != current_expansion and GetResourceAmount(chaos_expansion) >= GetUnitGoldCost(old_id[racial_expansion]) and GetLocationCreepStrength(GetUnitX(chaos_expansion), GetUnitY(chaos_expansion), expansion_radius) <= 0 and not CheckExpansionTaken(chaos_expansion) then
    set u = GetExpansionPeon()
    if u != null and UnitAlive(u) and u != expansion_peon and not chaos_expansion_run then
      set chaos_expansion_run = true
      call TQAddUnit2Job(2 * sleep_multiplier, BUILD_EXPANSION, 0, u, chaos_expansion)
      call IssueTargetOrderById(u, old_id[racial_expansion], chaos_expansion)
      call CreateDebugTag("chaos expansion", 10, u, 3.00, 1.50)
      call Trace("ExpansionBuilder: chaos expansion")
      set u = null
      return
    endif
    set u = null
  else
    set chaos_expansion = expansion_list[GetRandomInt(0, expansion_list_length - 1)]
    set chaos_expansion_run = false
  endif
endif
call Trace("ExpansionBuilder: Not ready to build mine")
```