### PR TITLE
Minor improvement to aggressive chat messages (colon -> parens)

### DIFF
--- a/common.eai
+++ b/common.eai
@@ -3192,7 +3192,7 @@ function DisplayChat takes integer chat, boolean ally, boolean enemy, boolean ob
       if chat ==  C_Goldproblem then
         set parsed_chat = parsed_chat + " " + ApplyTrans("CurrentGold") + ":" + Int2Str(GetGold())
       elseif chat == C_Ally or chat == C_Attack or chat == C_Megatarget then
-        set parsed_chat = parsed_chat + " " + ApplyTrans("Target") + ":" + ApplyTrans(GetChatVar("TargetColor"))
+        set parsed_chat = parsed_chat + " " + ApplyTrans("Target") + " (" + ApplyTrans(GetChatVar("TargetColor")) + ")"
       endif
       if chat == C_Greet then
         if (HaveStoredInteger(amaiCache, Int2Str(GREETINGS_NUM), Int2Str(i))) then


### PR DESCRIPTION
- Colon splitting race and color is very weird.
- Not using simple space because it's not i18n-friendly (some languages, such as English indeed, prefer the color before the race, while others prefer it the other way around)

Alternative: Define a ``bool`` for each language to define the color adjective position preference.