### PR TITLE
（devtool）Disable Debug

### DIFF
--- a/DisableDebug.bat
+++ b/DisableDebug.bat
@@ -1,5 +1,8 @@
 @ECHO OFF
-SET RESULTFWCOMPAT=0
+SET DisableROC=0
+SET DisableTFT=0
+SET DisableREFORGED=0
+SET Disable=0
 ECHO Disable Debug
 
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/common.ai
@@ -147,109 +150,111 @@ perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/undead.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
 
 pjass ROC\common.j Scripts\ROC\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 pjass ROC\common.j Scripts\ROC\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableROC=1
 jassparser ROC\common.j Scripts\ROC\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
-if "%RESULTFWCOMPAT%"=="1" (
+if "%errorlevel%"=="1" SET DisableROC=1
+if "%DisableROC%"=="1" (
   ECHO Disable Debug ROC scripts error
+  SET Disable=1
 ) else (
   ECHO Disable Debug ROC scripts finish
 )
 
-SET RESULTFWCOMPAT=0
-
 pjass TFT\common.j Scripts\TFT\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 pjass TFT\common.j Scripts\TFT\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableTFT=1
 jassparser TFT\common.j Scripts\TFT\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
-if "%RESULTFWCOMPAT%"=="1" (
+if "%errorlevel%"=="1" SET DisableTFT=1
+if "%DisableTFT%"=="1" (
   ECHO Disable Debug TFT scripts error
+  SET Disable=1
 ) else (
   ECHO Disable Debug TFT scripts finish
 )
 
-SET RESULTFWCOMPAT=0
-
 pjass REFORGED\common.j Scripts\REFORGED\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\common.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\elf.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\human.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\orc.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\undead.ai
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 pjass REFORGED\common.j Scripts\REFORGED\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 jassparser REFORGED\common.j Scripts\REFORGED\vsai\Blizzard.j
-if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%errorlevel%"=="1" SET DisableREFORGED=1
 
-if "%RESULTFWCOMPAT%"=="1" (
+if "%DisableREFORGED%"=="1" (
   ECHO Disable Debug REFORGED scripts error
-  exit /b %RESULTFWCOMPAT%
+  SET Disable=1
 ) else (
   ECHO Disable Debug REFORGED scripts finish
+)
+
+if "%Disable%"=="1" (
+  pause
 )

--- a/DisableDebug.bat
+++ b/DisableDebug.bat
@@ -1,13 +1,6 @@
 @ECHO OFF
+SET RESULTFWCOMPAT=0
 ECHO Disable Debug
-
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/common.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/Blizzard.j
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/elf.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/human.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/orc.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/undead.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/vsai/Blizzard.j
 
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/common.ai
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/Blizzard.j
@@ -24,6 +17,14 @@ perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/human.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/orc.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/undead.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/vsai/Blizzard.j
 
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/common.ai
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/Blizzard.j
@@ -49,14 +50,6 @@ perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/orc.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/undead.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/vsai/Blizzard.j
 
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/common.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/Blizzard.j
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/elf.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/human.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/orc.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/undead.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/vsai/Blizzard.j
-
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/common.ai
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/Blizzard.j
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/elf.ai
@@ -72,6 +65,14 @@ perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/human.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/orc.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/undead.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/vsai/Blizzard.j
 
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/common.ai
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/Blizzard.j
@@ -97,14 +98,6 @@ perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/orc.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/undead.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/vsai/Blizzard.j
 
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/common.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/elf.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/human.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/orc.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/undead.ai
-perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
-
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/common.ai
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/elf.ai
@@ -120,6 +113,14 @@ perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/human.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/orc.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/undead.ai
 perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
 
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/common.ai
 perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/Blizzard.j
@@ -144,3 +145,111 @@ perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/human.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/orc.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/undead.ai
 perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+pjass ROC\common.j Scripts\ROC\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\common.ai Scripts\ROC\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\common.ai Scripts\ROC\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass ROC\common.j Scripts\ROC\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser ROC\common.j Scripts\ROC\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%RESULTFWCOMPAT%"=="1" (
+  ECHO Disable Debug ROC scripts error
+) else (
+  ECHO Disable Debug ROC scripts finish
+)
+
+SET RESULTFWCOMPAT=0
+
+pjass TFT\common.j Scripts\TFT\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\common.ai Scripts\TFT\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\common.ai Scripts\TFT\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass TFT\common.j Scripts\TFT\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser TFT\common.j Scripts\TFT\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+if "%RESULTFWCOMPAT%"=="1" (
+  ECHO Disable Debug TFT scripts error
+) else (
+  ECHO Disable Debug TFT scripts finish
+)
+
+SET RESULTFWCOMPAT=0
+
+pjass REFORGED\common.j Scripts\REFORGED\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\common.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\elf.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\human.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\orc.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\common.ai Scripts\REFORGED\undead.ai
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+pjass REFORGED\common.j Scripts\REFORGED\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+jassparser REFORGED\common.j Scripts\REFORGED\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTFWCOMPAT=1
+
+if "%RESULTFWCOMPAT%"=="1" (
+  ECHO Disable Debug REFORGED scripts error
+  exit /b %RESULTFWCOMPAT%
+) else (
+  ECHO Disable Debug REFORGED scripts finish
+)

--- a/DisableDebug.bat
+++ b/DisableDebug.bat
@@ -1,3 +1,4 @@
+@ECHO OFF
 ECHO Disable Debug
 
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/common.ai

--- a/DisableDebug.bat
+++ b/DisableDebug.bat
@@ -40,6 +40,14 @@ perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/orc.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/undead.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/vsai/Blizzard.j
 
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/common.ai
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/Blizzard.j
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/elf.ai
@@ -80,6 +88,14 @@ perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/orc.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/undead.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/vsai/Blizzard.j
 
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/common.ai
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
 perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/elf.ai
@@ -119,3 +135,11 @@ perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/human.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/orc.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/undead.ai
 perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j

--- a/DisableDebug.bat
+++ b/DisableDebug.bat
@@ -1,0 +1,121 @@
+ECHO Disable Debug
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/common.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/Blizzard.j
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/elf.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/human.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/orc.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/undead.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/ROC/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/common.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/Blizzard.j
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/elf.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/human.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/orc.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/undead.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/TFT/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j
+
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/common.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/Blizzard.j
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/elf.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/human.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/orc.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/undead.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/REFORGED/vsai/Blizzard.j

--- a/MakeOptVER.bat
+++ b/MakeOptVER.bat
@@ -3,6 +3,13 @@ SET VER=%~1
 SET SILENT=%~2
 SET RESULTOPTVER=0
 ECHO Optimizing %VER% Scripts
+where perl
+if "%errorlevel%"=="1" SET RESULTOPTVER=1
+if "%RESULTOPTVER%"=="1" (
+  ECHO Compilation AMAI Optimization %VER% error
+  ECHO Please install Perl as a requirement to compile AMAI. Download : https://strawberryperl.com/
+  exit /b %RESULTOPTVER%
+)
 mkdir Scripts\OPT%VER%
 mkdir Scripts\OPT%VER%\vsai
 COPY Scripts\%VER%\common.ai Scripts\OPT%VER%\common.ai
@@ -16,6 +23,56 @@ COPY Scripts\%VER%\vsai\undead2.ai Scripts\OPT%VER%\vsai\undead2.ai
 COPY Scripts\%VER%\vsai\elf2.ai Scripts\OPT%VER%\vsai\elf2.ai
 COPY Scripts\%VER%\Blizzard.j Scripts\OPT%VER%\Blizzard.j
 COPY Scripts\%VER%\vsai\Blizzard.j Scripts\OPT%VER%\vsai\Blizzard.j
+ECHO _____________________________
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call TracePlayer)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call Trace)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call UpdateDebugTextTag)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call CreateDebug)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call DisplayToAllJobDebug)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+ECHO Disable Debug
+ECHO _____________________________
 perl Optimize.pl %VER%\common.j Scripts\OPT%VER%\common.ai -l %VER%\Races.txt Scripts\OPT%VER%\$2 Scripts\OPT%VER%\vsai\$3
 perl Optimize.pl -b Scripts\OPT%VER%\vsai\Blizzard.j
 perl Optimize.pl -b Scripts\OPT%VER%\Blizzard.j
@@ -45,6 +102,7 @@ pjass %VER%\common.j Scripts\OPT%VER%\common.ai Scripts\OPT%VER%\undead.ai
 if "%errorlevel%"=="1" SET RESULTOPTVER=1
 jassparser %VER%\common.j Scripts\OPT%VER%\common.ai Scripts\OPT%VER%\undead.ai
 if "%errorlevel%"=="1" SET RESULTMAKEVER=1
+ECHO _____________________________
 pjass %VER%\common.j Scripts\OPT%VER%\common.ai Scripts\OPT%VER%\vsai\elf2.ai
 if "%errorlevel%"=="1" SET RESULTMAKEVER=1
 jassparser %VER%\common.j Scripts\OPT%VER%\common.ai Scripts\OPT%VER%\vsai\elf2.ai
@@ -67,7 +125,12 @@ if "%errorlevel%"=="1" SET RESULTMAKEVER=1
 ECHO _____________________________
 pjass %VER%\common.j Scripts\OPT%VER%\vsai\Blizzard.j
 if "%errorlevel%"=="1" SET RESULTOPTVER=1
+jassparser %VER%\common.j Scripts\OPT%VER%\vsai\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTOPTVER=1
+ECHO _____________________________
 pjass %VER%\common.j Scripts\OPT%VER%\Blizzard.j
+if "%errorlevel%"=="1" SET RESULTOPTVER=1
+jassparser %VER%\common.j Scripts\OPT%VER%\Blizzard.j
 if "%errorlevel%"=="1" SET RESULTOPTVER=1
 if "%RESULTOPTVER%"=="1" (
   ECHO Optimization %VER% error


### PR DESCRIPTION
After the release of the version, the debugging information is meaningless to the player. The player will not turn on the debugging switch, nor need to care about this information

And the debugging switch itself is turned off, which means that all problem feedback, normally, cannot be accompanied by debugging information

There is an issue here, although all debugging information needs to be turned on to display
But before it is displayed, it has actually run completely

For example, the player cannot see this information, but before entering it into `CreateDebugTagLoc`, the data has already been calculated. This means that the system has run this code, and in the end, only not shows
`Int2Str(minecount)   Int2Str(ownedmines)`

`call CreateDebugTagLoc("Mines:" + Int2Str(minecount) +" Taken:" + Int2Str(claimedMines) + " Own:" + Int2Str(ownedmines), 10, GetUnitX(expa), GetUnitY(expa), 10.00, 1.80)`

This will occupy system resources, especially since I still stubbornly believe that the extensive use of strings, especially the plus sign, will cause excretion problems, and some people in the Chinese community say that strings cannot be excreted

Therefore, I provided a tool that can disable debugging functions for compiled scripts in the officially released version, saving system resource

But you need to run it when publishing