### PR TITLE
Let Random Hero Run

### DIFF
--- a/Blizzard.eai
+++ b/Blizzard.eai
@@ -107,6 +107,14 @@
     button %1_button = null
 #ENDINCLUDE
 
+    trigger Random_Hero = null
+    triggeraction Random_Hero_Action = null
+    integer array RandomHeroNum
+    integer array RandomHero_Max
+    sound array RandomHeroSound
+    boolean RandomHero = true  // if do not want random hero, set this to false
+    boolean RandomHeroRun = false  // do not change this
+
     string chat_no_ally = ""
     string you_no_gold = ""
     string i_no_gold = ""
@@ -559,6 +567,157 @@ endfunction
 
 function ShowBoard takes nothing returns nothing
   call LeaderboardDisplay(color_board, not IsLeaderboardDisplayed(color_board))
+endfunction
+
+//===========================================================================
+// Random Hero
+//===========================================================================
+function SetStartHero_d takes player p, race r, location l returns nothing
+  local unit u = null
+  if GetPlayerController(p) == MAP_CONTROL_COMPUTER then
+    if r == RACE_NIGHTELF then
+      set u = CreateUnit(p, RandomHeroNum[GetRandomInt(8, 11)], GetLocationX(l), GetLocationY(l) - GetRandomInt(350, 450), bj_UNIT_FACING)
+    elseif r == RACE_ORC then
+      set u = CreateUnit(p, RandomHeroNum[GetRandomInt(12, 15)], GetLocationX(l), GetLocationY(l) - GetRandomInt(350, 450), bj_UNIT_FACING)
+    elseif r == RACE_UNDEAD then
+      set u = CreateUnit(p, RandomHeroNum[GetRandomInt(16, 19)], GetLocationX(l), GetLocationY(l) - GetRandomInt(350, 450), bj_UNIT_FACING)
+    elseif r == RACE_HUMAN then
+      set u = CreateUnit(p, RandomHeroNum[GetRandomInt(20, 23)], GetLocationX(l), GetLocationY(l) - GetRandomInt(350, 450), bj_UNIT_FACING)
+    endif
+  else
+    set u = CreateUnit(p, RandomHeroNum[GetRandomInt(0, 23)], GetLocationX(l), GetLocationY(l) - GetRandomInt(350, 450), bj_UNIT_FACING)
+  endif
+  call UnitAddItemById(u, 'stwp')
+  call RemoveLocation(l)
+  set u = null
+endfunction
+
+function SetOtherHero takes nothing returns nothing
+  local unit u = GetTrainedUnit()
+  local unit t = GetSoldUnit()
+  local unit x = null
+  local location l = null
+  local player p = null
+  local integer c = GetRandomInt(0, 23)
+  local integer i = 0
+  if u == null then
+    set u = t
+  endif
+  set p = GetOwningPlayer(u)
+  set i = GetPlayerId(p)
+  if GetPlayerController(p) == MAP_CONTROL_COMPUTER or RandomHero_Max[i] > 2 then
+    set u = null
+    set t = null
+    set p = null
+    return
+  endif
+  call ShowUnit(u, false)
+  call SetUnitOwner(u, Player(PLAYER_NEUTRAL_PASSIVE), false)
+  set x = u
+  set u = CreateUnit(p, RandomHeroNum[c], GetUnitX(x), GetUnitY(x), bj_UNIT_FACING)
+  call KillUnit(x)  // Prevent the unit from continuing to exist
+  call RemoveUnit(x)
+  if GetLocalPlayer() == p then
+    call PlaySoundOnUnitBJ(RandomHeroSound[c], 100, u)
+  endif
+  set c = GetBJMaxPlayers()
+  set RandomHero_Max[i] = RandomHero_Max[i] + 1
+  set RandomHero_Max[c] = RandomHero_Max[c] - 1
+  if t == null then
+    set l = GetUnitRallyPoint(GetTriggerUnit())
+    if l != null then
+      call IssuePointOrderLocBJ(u, "move", l)
+      call RemoveLocation(l)
+      set l = null
+    endif
+  endif
+  call SetPlayerTechMaxAllowed(p, 'HERO', 4)
+  set u = null
+  set t = null
+  set x = null
+  set p = null
+  if RandomHero_Max[c] < 1 then
+    call TriggerRemoveAction(Random_Hero, Random_Hero_Action)
+    call DestroyTrigger(Random_Hero)
+    set Random_Hero = null
+  endif
+endfunction
+
+function InitRandomHero takes nothing returns nothing
+  local integer i = 0
+  local integer c = GetBJMaxPlayers()
+  local player p = null
+  if RandomHero and IsMapFlagSet(MAP_RANDOM_HERO) and Random_Hero == null then
+    set Random_Hero = CreateTrigger()
+    set RandomHeroRun = true
+    call SetMapFlag(MAP_RANDOM_HERO, false)
+    set RandomHeroNum[0] = 'Nngs'
+    set RandomHeroNum[1] = 'Nbst'
+    set RandomHeroNum[2] = 'Nbrn'
+    set RandomHeroNum[3] = 'Nplh'
+    set RandomHeroNum[4] = 'Npbm'
+    set RandomHeroNum[5] = 'Ntin'
+    set RandomHeroNum[6] = 'Nfir'
+    set RandomHeroNum[7] = 'Nalc'
+    set RandomHeroNum[8] = 'Edem'
+    set RandomHeroNum[9] = 'Ekee'
+    set RandomHeroNum[10] = 'Emoo'
+    set RandomHeroNum[11] = 'Ewar'
+    set RandomHeroNum[12] = 'Obla'
+    set RandomHeroNum[13] = 'Ofar'
+    set RandomHeroNum[14] = 'Otch'
+    set RandomHeroNum[15] = 'Oshd'
+    set RandomHeroNum[16] = 'Udea'
+    set RandomHeroNum[17] = 'Udre'
+    set RandomHeroNum[18] = 'Ulic'
+    set RandomHeroNum[19] = 'Ucrl'
+    set RandomHeroNum[20] = 'Hamg'
+    set RandomHeroNum[21] = 'Hpal'
+    set RandomHeroNum[22] = 'Hmkg'
+    set RandomHeroNum[23] = 'Hblm'
+    set RandomHeroSound[0] = CreateSound("Units\\Naga\\LadyVashj\\LadyVashjReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[1] = CreateSound("Units\\Creeps\\Beastmaster\\OgreBeastMasterReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[2] = CreateSound("Units\\Creeps\\BansheeRanger\\DarkRangerReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[3] = CreateSound("Units\\Demon\\HeroPitLord\\HPitLordReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[4] = CreateSound("Units\\Creeps\\PandarenBrewmaster\\PandarenBrewmasterReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[5] = CreateSound("Units\\Creeps\\HeroTinker\\HeroTinkerReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[6] = CreateSound("Units\\Creeps\\HeroFlameLord\\HeroFireLordReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[7] = CreateSound("Units\\Creeps\\HEROGoblinALCHEMIST\\HeroAlchemistReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[8] = CreateSound("Units\\NightElf\\HeroDemonHunter\\HeroDemonHunterReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[9] = CreateSound("Units\\NightElf\\HeroKeeperOfTheGrove\\KeeperOfTheGroveReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[10] = CreateSound("Units\\NightElf\\HeroMoonPriestess\\HeroMoonPriestessReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[11] = CreateSound("Units\\NightElf\\HeroWarden\\HeroWardenReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[12] = CreateSound("Units\\Orc\\HeroBladeMaster\\HeroBladeMasterReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[13] = CreateSound("Units\\Orc\\HeroFarseer\\HeroFarseerReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[14] = CreateSound("Units\\Orc\\HeroTaurenChieftain\\HeroTaurenChieftainReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[15] = CreateSound("Units\\Orc\\HeroShadowHunter\\ShadowHunterReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[16] = CreateSound("Units\\Undead\\HeroDeathKnight\\DeathKnightReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[17] = CreateSound("Units\\Undead\\HeroDreadLord\\HeroDreadlordReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[18] = CreateSound("Units\\Undead\\HeroLich\\HeroLichReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[19] = CreateSound("Units\\Undead\\HeroCryptLord\\NerubianCryptLordReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[20] = CreateSound("Units\\Human\\HeroArchMage\\HeroArchMageReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[21] = CreateSound("Units\\Human\\HeroPaladin\\HeroPaladinReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[22] = CreateSound("Units\\Human\\HeroMountainKing\\HeroMountainKingReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHeroSound[23] = CreateSound("Units\\Human\\HeroBloodElf\\BloodElfMageReady1.wav", false, true, true, 10, 10, "HeroAcksEAX")
+    set RandomHero_Max[c] = 0
+    loop
+      exitwhen i >= c
+      set p = Player(i)
+      if GetPlayerSlotState(p) == PLAYER_SLOT_STATE_PLAYING then
+        if GetPlayerController(p) != MAP_CONTROL_COMPUTER then
+          set RandomHero_Max[i] = 1
+          set RandomHero_Max[c] = RandomHero_Max[c] + 2
+          call DisplayTimedTextToPlayer(p, 0, 0, 7, "AMAI Real Player Random Hero: |cff00ff00[on]|r")
+          call TriggerRegisterPlayerUnitEvent(Random_Hero, p, EVENT_PLAYER_UNIT_TRAIN_FINISH, filterMeleeTrainedUnitIsHeroBJ)
+        endif
+        call SetStartHero_d(p, GetPlayerRace(p), GetStartLocationLoc(GetPlayerStartLocation(p)))  // include AI
+      endif
+      set i = i + 1
+    endloop
+    call TriggerRegisterPlayerUnitEvent(Random_Hero, Player(PLAYER_NEUTRAL_PASSIVE), EVENT_PLAYER_UNIT_SELL, filterMeleeTrainedUnitIsHeroBJ)
+    set Random_Hero_Action = TriggerAddAction(Random_Hero, function SetOtherHero)
+    set p = null
+  endif
 endfunction
 
 //===========================================================================
@@ -2014,4 +2173,5 @@ endfunction
     call InitHCL()
     call InitCommander()
     call InitZoom()
+    call InitRandomHero()
 #INCLUDE <$VER$\tmp\Blizzard6.j>

--- a/Blizzard3.eai
+++ b/Blizzard3.eai
@@ -35,11 +35,12 @@ endfunction
 
 //===========================================================================
 function MeleeStartingAI takes nothing returns nothing
-    local integer index
+    local integer index = 0
     local player  indexPlayer
     local race    indexRace
-
-    set index = 0
+    if RandomHeroRun then
+      call SetMapFlag(MAP_RANDOM_HERO, true)
+    endif
     loop
         set indexPlayer = Player(index)
         if (GetPlayerSlotState(indexPlayer) == PLAYER_SLOT_STATE_PLAYING) then
@@ -71,6 +72,8 @@ function MeleeStartingAI takes nothing returns nothing
         endif
 
         set index = index + 1
-        exitwhen index == GetBJMaxPlayers()
+        exitwhen index >= GetBJMaxPlayers()
     endloop
+    set indexPlayer = null
+    set indexRace = null
 endfunction

--- a/Blizzard3VAI.eai
+++ b/Blizzard3VAI.eai
@@ -40,11 +40,12 @@ endfunction
 
 //===========================================================================
 function MeleeStartingAI takes nothing returns nothing
-    local integer index
+    local integer index = 0
     local player  indexPlayer
     local race    indexRace
-
-    set index = 0
+    if RandomHeroRun then
+      call SetMapFlag(MAP_RANDOM_HERO, true)
+    endif
     loop
         set indexPlayer = Player(index)
         if (GetPlayerSlotState(indexPlayer) == PLAYER_SLOT_STATE_PLAYING) then
@@ -76,7 +77,7 @@ function MeleeStartingAI takes nothing returns nothing
         endif
 
         set index = index + 1
-        exitwhen index == GetBJMaxPlayers()
+        exitwhen index >= GetBJMaxPlayers()
     endloop
     set indexPlayer = null
     set indexRace = null

--- a/MakeOptVER.bat
+++ b/MakeOptVER.bat
@@ -26,6 +26,15 @@ COPY Scripts\%VER%\vsai\Blizzard.j Scripts\OPT%VER%\vsai\Blizzard.j
 
 ECHO _____________________________
 ECHO Disable Debug
+
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/common.ai
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/Blizzard.j
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/elf.ai
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/human.ai
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/orc.ai
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/undead.ai
+perl -i -pe"s#(call TraceN)#//$1#g" Scripts/OPT%VER%/vsai/Blizzard.j
+
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/common.ai
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/Blizzard.j
 perl -i -pe"s#(debug call Trace)#//$1#g" Scripts/OPT%VER%/elf.ai

--- a/REFORGED/Elf/BuildSequence.ai
+++ b/REFORGED/Elf/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, ANCIENT_WAR, false, 0, ELF_ALTAR, 12)
+    else
       call AddBlock(1, ELF_ALTAR, false, 0, ANCIENT_WAR, 16)
       call AddBlock(1, ELF_ALTAR, true, 0, DEN_OF_WONDERS, 36)
       call AddBlock(1, ELF_ALTAR, false, 0, MOON_WELL, 16)

--- a/REFORGED/Human/BuildSequence.ai
+++ b/REFORGED/Human/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, BARRACKS, false, 0, HUMAN_ALTAR, 12)
+    else
       call AddBlock(1, HUMAN_ALTAR, false, 0, ARCANE_VAULT, 16)
       call AddBlock(1, HUMAN_ALTAR, false, 0, HOUSE, 16)
       call AddBlock(1, HUMAN_ALTAR, false, 0, BARRACKS, 16)

--- a/REFORGED/Orc/BuildSequence.ai
+++ b/REFORGED/Orc/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, ORC_BARRACKS, false, 0, ORC_ALTAR, 12)
+    else
       call AddBlock(1, ORC_ALTAR, false, 0, BURROW, 16)
       call AddBlock(1, ORC_ALTAR, false, 0, ORC_BARRACKS, 16)
       call AddBlock(1, ORC_ALTAR, true, 0, VOODOO_LOUNGE, 36)

--- a/REFORGED/Undead/BuildSequence.ai
+++ b/REFORGED/Undead/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, CRYPT, false, 0, UNDEAD_ALTAR, 12)
+    else
       call AddBlock(1, UNDEAD_ALTAR, true, 0, TOMB_OF_RELICS, 36)
       call AddBlock(1, UNDEAD_ALTAR, false, 0, CRYPT, 16)
       call AddBlock(1, UNDEAD_ALTAR, false, 0, ZIGGURAT_1, 16)

--- a/TFT/Elf/BuildSequence.ai
+++ b/TFT/Elf/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, ANCIENT_WAR, false, 0, ELF_ALTAR, 12)
+    else
       call AddBlock(1, ELF_ALTAR, false, 0, ANCIENT_WAR, 16)
       call AddBlock(1, ELF_ALTAR, true, 0, DEN_OF_WONDERS, 36)
       call AddBlock(1, ELF_ALTAR, false, 0, MOON_WELL, 16)

--- a/TFT/Human/BuildSequence.ai
+++ b/TFT/Human/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, BARRACKS, false, 0, HUMAN_ALTAR, 12)
+    else
       call AddBlock(1, HUMAN_ALTAR, false, 0, ARCANE_VAULT, 16)
       call AddBlock(1, HUMAN_ALTAR, false, 0, HOUSE, 16)
       call AddBlock(1, HUMAN_ALTAR, false, 0, BARRACKS, 16)

--- a/TFT/Orc/BuildSequence.ai
+++ b/TFT/Orc/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, ORC_BARRACKS, false, 0, ORC_ALTAR, 12)
+    else
       call AddBlock(1, ORC_ALTAR, false, 0, BURROW, 16)
       call AddBlock(1, ORC_ALTAR, false, 0, ORC_BARRACKS, 16)
       call AddBlock(1, ORC_ALTAR, true, 0, VOODOO_LOUNGE, 36)

--- a/TFT/Undead/BuildSequence.ai
+++ b/TFT/Undead/BuildSequence.ai
@@ -4,7 +4,9 @@
 function global_init_strategy takes nothing returns nothing
     call SetTierBlock(1, 0.75, 60, true)
     call SetTierBlock(2, 0.75, 90, true)
-    if not IsMapFlagSet(MAP_RANDOM_HERO) then
+    if IsMapFlagSet(MAP_RANDOM_HERO) then
+      call AddBlock(1, CRYPT, false, 0, UNDEAD_ALTAR, 12)
+    else
       call AddBlock(1, UNDEAD_ALTAR, true, 0, TOMB_OF_RELICS, 36)
       call AddBlock(1, UNDEAD_ALTAR, false, 0, CRYPT, 16)
       call AddBlock(1, UNDEAD_ALTAR, false, 0, ZIGGURAT_1, 16)


### PR DESCRIPTION
- Random Hero , you can open Random Hero on room , than real human player can use this
- if Random Hero , no need first build ALTAR
- （detool） Disable Debug add TraceN

Note : not test the use of resurrection symbols or triggers to obtain new hero

But it can indeed run .. At least in standard battles



As development progresses
I have introduced many non-standard features
such as the original Fountain of Power
now the random hero
the blockage fix you just merged (the first item may be discarded, in fact, in non-standard maps, hero exclusive items will be placed in the first grid)
My branch has already supported Corrupt Moon Well
Not to mention my branch and teleportation effects...
`And I hope you can achieve non-standard hero learning skill support in the future`

Do maybe need to rewrite the declaration to emphasize the standardization of the WE data
